### PR TITLE
merge fixes for a few CEDAR field artifact validation bugs

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/core/NumericType.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/NumericType.java
@@ -10,7 +10,7 @@ import static org.metadatacenter.model.ModelNodeNames.XSD_IRI;
 public enum NumericType
 {
   DECIMAL("xsd:decimal"),
-  INTEGER("xsd:integer"),
+  INTEGER("xsd:int"),
   LONG("xsd:long"),
   BYTE("xsd:byte"),
   SHORT("xsd:short"),

--- a/src/main/java/org/metadatacenter/artifacts/model/core/NumericValueConstraints.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/NumericValueConstraints.java
@@ -19,7 +19,7 @@ public non-sealed interface NumericValueConstraints extends ValueConstraints
 
   Optional<Number> maxValue();
 
-  Optional<Integer> decimalPlaces();
+  Optional<Integer> decimalPlace();
 
   Optional<String> unitOfMeasure();
 
@@ -100,7 +100,7 @@ public non-sealed interface NumericValueConstraints extends ValueConstraints
 }
 
 record NumericValueConstraintsRecord(NumericType numberType,
-                                     Optional<Number> minValue, Optional<Number> maxValue, Optional<Integer> decimalPlaces,
+                                     Optional<Number> minValue, Optional<Number> maxValue, Optional<Integer> decimalPlace,
                                      Optional<String> unitOfMeasure, Optional<NumericDefaultValue> defaultValue,
                                      boolean requiredValue, boolean multipleChoice)
   implements NumericValueConstraints
@@ -112,7 +112,7 @@ record NumericValueConstraintsRecord(NumericType numberType,
     validateOptionalFieldNotNull(this, unitOfMeasure, VALUE_CONSTRAINTS_UNIT_OF_MEASURE);
     validateOptionalFieldNotNull(this, minValue, VALUE_CONSTRAINTS_MIN_NUMBER_VALUE);
     validateOptionalFieldNotNull(this, maxValue, VALUE_CONSTRAINTS_MAX_NUMBER_VALUE);
-    validateOptionalFieldNotNull(this, decimalPlaces, VALUE_CONSTRAINTS_DECIMAL_PLACE);
+    validateOptionalFieldNotNull(this, decimalPlace, VALUE_CONSTRAINTS_DECIMAL_PLACE);
     validateOptionalFieldNotNull(this, defaultValue, VALUE_CONSTRAINTS_DEFAULT_VALUE);
   }
 }

--- a/src/main/java/org/metadatacenter/artifacts/model/core/TemporalFieldUi.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/TemporalFieldUi.java
@@ -8,16 +8,16 @@ public non-sealed interface TemporalFieldUi extends FieldUi
 
   InputTimeFormat inputTimeFormat();
 
-  boolean timeZoneEnabled();
+  boolean timezoneEnabled();
 
   boolean hidden();
 
   default boolean valueRecommendationEnabled() { return false; }
 
   static TemporalFieldUi create(TemporalGranularity temporalGranularity,
-    InputTimeFormat inputTimeFormat, boolean timeZoneEnabled,  boolean hidden)
+    InputTimeFormat inputTimeFormat, boolean timezoneEnabled,  boolean hidden)
   {
-    return new TemporalFieldUiRecord(FieldInputType.TEMPORAL, temporalGranularity, inputTimeFormat, timeZoneEnabled, hidden);
+    return new TemporalFieldUiRecord(FieldInputType.TEMPORAL, temporalGranularity, inputTimeFormat, timezoneEnabled, hidden);
   }
 
   static Builder builder() {
@@ -29,7 +29,7 @@ public non-sealed interface TemporalFieldUi extends FieldUi
     private FieldInputType inputType = FieldInputType.TEMPORAL;
     private TemporalGranularity temporalGranularity;
     private InputTimeFormat inputTimeFormat = InputTimeFormat.TWELVE_HOUR;
-    boolean timeZoneEnabled = false;
+    boolean timezoneEnabled = false;
     private boolean hidden = false;
 
     private Builder()
@@ -48,9 +48,9 @@ public non-sealed interface TemporalFieldUi extends FieldUi
       return this;
     }
 
-    public Builder withTimeZoneEnabled(boolean timeZoneEnabled)
+    public Builder withTimezoneEnabled(boolean timezoneEnabled)
     {
-      this.timeZoneEnabled = timeZoneEnabled;
+      this.timezoneEnabled = timezoneEnabled;
       return this;
     }
 
@@ -62,13 +62,13 @@ public non-sealed interface TemporalFieldUi extends FieldUi
 
     public TemporalFieldUi build()
     {
-      return new TemporalFieldUiRecord(inputType, temporalGranularity, inputTimeFormat, timeZoneEnabled, hidden);
+      return new TemporalFieldUiRecord(inputType, temporalGranularity, inputTimeFormat, timezoneEnabled, hidden);
     }
   }
 }
 
 record TemporalFieldUiRecord(FieldInputType inputType, TemporalGranularity temporalGranularity, InputTimeFormat inputTimeFormat,
-                             boolean timeZoneEnabled, boolean hidden) implements TemporalFieldUi
+                             boolean timezoneEnabled, boolean hidden) implements TemporalFieldUi
 {
   public TemporalFieldUiRecord
   {

--- a/src/main/java/org/metadatacenter/artifacts/model/core/ValueConstraints.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/ValueConstraints.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 public sealed interface ValueConstraints permits TextValueConstraints, NumericValueConstraints,
   ControlledTermValueConstraints, TemporalValueConstraints
 {
-  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   boolean requiredValue();
 
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/metadatacenter/artifacts/model/core/builders/TemporalFieldBuilder.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/builders/TemporalFieldBuilder.java
@@ -46,7 +46,7 @@ public final class TemporalFieldBuilder extends FieldSchemaArtifactBuilder
 
   public TemporalFieldBuilder withTimeZoneEnabled(boolean timeZoneEnabled)
   {
-    fieldUiBuilder.withTimeZoneEnabled(timeZoneEnabled);
+    fieldUiBuilder.withTimezoneEnabled(timeZoneEnabled);
     return this;
   }
 

--- a/src/main/java/org/metadatacenter/artifacts/model/renderer/ExcelArtifactRenderer.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/renderer/ExcelArtifactRenderer.java
@@ -242,7 +242,7 @@ public class ExcelArtifactRenderer
         TemporalValueConstraints temporalValueConstraints = (TemporalValueConstraints)valueConstraints.get();
         TemporalFieldUi temporalFieldUi = fieldUi.asTemporalFieldUi(); // TODO Temporary until we use typed switch
         TemporalType temporalType = temporalValueConstraints.temporalType();
-        String temporalFormatString = getTemporalFormatString(fieldName, temporalType, temporalFieldUi.temporalGranularity(), temporalFieldUi.inputTimeFormat(), temporalFieldUi.timeZoneEnabled());
+        String temporalFormatString = getTemporalFormatString(fieldName, temporalType, temporalFieldUi.temporalGranularity(), temporalFieldUi.inputTimeFormat(), temporalFieldUi.timezoneEnabled());
         return temporalFormatString;
 
       } else
@@ -693,7 +693,7 @@ public class ExcelArtifactRenderer
       if (valueConstraints.isPresent()) {
         NumericValueConstraints numericValueConstraints = valueConstraints.get().asNumericValueConstraints();
         String formatString = getNumericFormatString(fieldName, numericValueConstraints.numberType(),
-          numericValueConstraints.decimalPlaces(), numericValueConstraints.unitOfMeasure());
+          numericValueConstraints.decimalPlace(), numericValueConstraints.unitOfMeasure());
         cellStyle.setDataFormat(dataFormat.getFormat(formatString));
       } else {
         String formatString = getNumericFormatString(fieldName, NumericType.DOUBLE, Optional.empty(), Optional.empty());
@@ -704,7 +704,7 @@ public class ExcelArtifactRenderer
       if (valueConstraints.isPresent()) {
         TemporalValueConstraints temporalValueConstraints = valueConstraints.get().asTemporalValueConstraints();
         String formatString = getTemporalFormatString(fieldName, temporalValueConstraints.temporalType(),
-          temporalFieldUi.temporalGranularity(), temporalFieldUi.inputTimeFormat(), temporalFieldUi.timeZoneEnabled());
+          temporalFieldUi.temporalGranularity(), temporalFieldUi.inputTimeFormat(), temporalFieldUi.timezoneEnabled());
         cellStyle.setDataFormat(dataFormat.getFormat(formatString));
       }
     }

--- a/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonSchemaArtifactRenderer.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonSchemaArtifactRenderer.java
@@ -452,8 +452,11 @@ public class JsonSchemaArtifactRenderer implements ArtifactRenderer<ObjectNode>
         rendering.withArray(JSON_LD_TYPE).add(jsonLdType.toString());
     }
 
-    if (artifact.jsonLdId().isPresent())
+    if (artifact.jsonLdId().isPresent()) {
       rendering.put(JSON_LD_ID, artifact.jsonLdId().get().toString());
+    } else {
+      rendering.putNull(JSON_LD_ID);
+    }
 
     return rendering;
   }
@@ -474,17 +477,29 @@ public class JsonSchemaArtifactRenderer implements ArtifactRenderer<ObjectNode>
   {
     ObjectNode rendering = mapper.createObjectNode();
 
-    if (monitoredArtifact.createdBy().isPresent())
+    if (monitoredArtifact.createdBy().isPresent()) {
       rendering.put(PAV_CREATED_BY, monitoredArtifact.createdBy().get().toString());
+    } else {
+      rendering.putNull(PAV_CREATED_BY);
+    }
 
-    if (monitoredArtifact.modifiedBy().isPresent())
+    if (monitoredArtifact.modifiedBy().isPresent()) {
       rendering.put(OSLC_MODIFIED_BY, monitoredArtifact.modifiedBy().get().toString());
+    } else {
+      rendering.putNull(OSLC_MODIFIED_BY);
+    }
 
-    if (monitoredArtifact.createdOn().isPresent())
+    if (monitoredArtifact.createdOn().isPresent()) {
       rendering.put(PAV_CREATED_ON, monitoredArtifact.createdOn().get().toString());
+    } else {
+      rendering.putNull(PAV_CREATED_ON);
+    }
 
-    if (monitoredArtifact.lastUpdatedOn().isPresent())
+    if (monitoredArtifact.lastUpdatedOn().isPresent()) {
       rendering.put(PAV_LAST_UPDATED_ON, monitoredArtifact.lastUpdatedOn().get().toString());
+    } else {
+      rendering.putNull(PAV_LAST_UPDATED_ON);
+    }
 
     return rendering;
   }
@@ -922,7 +937,15 @@ public class JsonSchemaArtifactRenderer implements ArtifactRenderer<ObjectNode>
    *     "oslc": "http://open-services.net/ns/core#",
    *     "bibo": "http://purl.org/ontology/bibo/",
    *     "xsd": "http://www.w3.org/2001/XMLSchema#",
-   *     "skos": "http://www.w3.org/2004/02/skos/core#"
+   *     "skos": "http://www.w3.org/2004/02/skos/core#",
+   *     "schema:name": { "@type": "xsd:string" },
+   *     "schema:description": { "@type": "xsd:string" },
+   *     "pav:createdOn": { "@type": "xsd:dateTime" },
+   *     "pav:createdBy": { "@type": "@id" },
+   *     "pav:lastUpdatedOn": { "@type": "xsd:dateTime" },
+   *     "oslc:modifiedBy": { "@type": "@id" },
+   *     "skos:prefLabel": { "@type": "xsd:string" },
+   *     "skos:altLabel": { "@type": "xsd:string" }
    *   }
    * </pre>
    */
@@ -933,11 +956,20 @@ public class JsonSchemaArtifactRenderer implements ArtifactRenderer<ObjectNode>
     for (var entry: FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet())
       rendering.put(entry.getKey(), entry.getValue().toString());
 
+    rendering.put(SCHEMA_ORG_NAME, renderXsdStringJsonLdSpecification());
+    rendering.put(SCHEMA_ORG_DESCRIPTION, renderXsdStringJsonLdSpecification());
+    rendering.put(PAV_CREATED_ON, renderXsdDateTimeJsonLdSpecification());
+    rendering.put(PAV_CREATED_BY, renderIriJsonLdSpecification());
+    rendering.put(PAV_LAST_UPDATED_ON, renderXsdDateTimeJsonLdSpecification());
+    rendering.put(OSLC_MODIFIED_BY, renderIriJsonLdSpecification());
+    rendering.put(SKOS_PREFLABEL, renderXsdStringJsonLdSpecification());
+    rendering.put(SKOS_ALTLABEL, renderXsdStringJsonLdSpecification());
+
     return rendering;
   }
 
   /**
-   * Generate JSON-LD @context prefix specification for field schema artifacts
+   * Generate JSON-LD @context prefix specification for static field schema artifacts
    * <p></p>
    * Defined as follows:
    * <pre>
@@ -1192,7 +1224,7 @@ public class JsonSchemaArtifactRenderer implements ArtifactRenderer<ObjectNode>
    * <p>
    * Defined as follows:
    * <pre>
-   *   { "type": "string", "format": "termUri" }
+   *   { "type": "string", "format": "uri" }
    * </pre>
    */
   private ObjectNode renderUriJsonSchemaTypeSpecification()
@@ -1200,7 +1232,7 @@ public class JsonSchemaArtifactRenderer implements ArtifactRenderer<ObjectNode>
     ObjectNode rendering = mapper.createObjectNode();
 
     rendering.put(JSON_SCHEMA_TYPE, "string");
-    rendering.put(ModelNodeNames.JSON_SCHEMA_FORMAT, "termUri");
+    rendering.put(ModelNodeNames.JSON_SCHEMA_FORMAT, "uri");
 
     return rendering;
   }
@@ -1234,7 +1266,7 @@ public class JsonSchemaArtifactRenderer implements ArtifactRenderer<ObjectNode>
    * <p>
    * Defined as follows:
    * <pre>
-   * { "type": "array", "minItems": [minItems], "items": { "type": "string", "format": "termUri" }, "uniqueItems": [uniqueItems] }
+   * { "type": "array", "minItems": [minItems], "items": { "type": "string", "format": "uri" }, "uniqueItems": [uniqueItems] }
    * </pre>
    */
   private ObjectNode renderUriArrayJsonSchemaTypeSpecification(int minItems, boolean uniqueItems)
@@ -1245,7 +1277,7 @@ public class JsonSchemaArtifactRenderer implements ArtifactRenderer<ObjectNode>
     rendering.put(ModelNodeNames.JSON_SCHEMA_MIN_ITEMS, minItems);
     rendering.put(ModelNodeNames.JSON_SCHEMA_ITEMS, mapper.createObjectNode());
     rendering.withObject( "/" + ModelNodeNames.JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_TYPE, "string");
-    rendering.withObject( "/" + ModelNodeNames.JSON_SCHEMA_ITEMS).put(ModelNodeNames.JSON_SCHEMA_FORMAT, "termUri");
+    rendering.withObject( "/" + ModelNodeNames.JSON_SCHEMA_ITEMS).put(ModelNodeNames.JSON_SCHEMA_FORMAT, "uri");
     rendering.put(ModelNodeNames.JSON_SCHEMA_UNIQUE_ITEMS, uniqueItems);
 
     return rendering;

--- a/src/main/java/org/metadatacenter/artifacts/model/renderer/YamlArtifactRenderer.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/renderer/YamlArtifactRenderer.java
@@ -253,7 +253,7 @@ public class YamlArtifactRenderer implements ArtifactRenderer<Map<String, Object
       rendering.put(CONTENT, fieldUi.asStaticFieldUi()._content());
     else if (fieldUi.isTemporal()) {
 
-      rendering.put(TIME_ZONE, fieldUi.asTemporalFieldUi().timeZoneEnabled());
+      rendering.put(TIME_ZONE, fieldUi.asTemporalFieldUi().timezoneEnabled());
 
       rendering.put(GRANULARITY, fieldUi.asTemporalFieldUi().temporalGranularity());
 
@@ -384,8 +384,8 @@ public class YamlArtifactRenderer implements ArtifactRenderer<Map<String, Object
       if (numericValueConstraints.maxValue().isPresent())
         rendering.put(MAX_VALUE, numericValueConstraints.maxValue().get());
 
-      if (numericValueConstraints.decimalPlaces().isPresent())
-        rendering.put(DECIMAL_PLACES, numericValueConstraints.decimalPlaces().get());
+      if (numericValueConstraints.decimalPlace().isPresent())
+        rendering.put(DECIMAL_PLACES, numericValueConstraints.decimalPlace().get());
 
       if (numericValueConstraints.unitOfMeasure().isPresent())
         rendering.put(UNIT, numericValueConstraints.unitOfMeasure().get());

--- a/src/main/java/org/metadatacenter/artifacts/redcap/TemplateSchemaArtifact2REDCapConvertor.java
+++ b/src/main/java/org/metadatacenter/artifacts/redcap/TemplateSchemaArtifact2REDCapConvertor.java
@@ -166,8 +166,8 @@ public class TemplateSchemaArtifact2REDCapConvertor
           return Optional.of(REDCapConstants.INTEGER_TEXTFIELD_VALIDATION);
         }
         case DECIMAL, FLOAT, DOUBLE -> {
-          if (numericValueConstraints.decimalPlaces().isPresent()) {
-            Integer decimalPlaces = numericValueConstraints.decimalPlaces().get();
+          if (numericValueConstraints.decimalPlace().isPresent()) {
+            Integer decimalPlaces = numericValueConstraints.decimalPlace().get();
             if (decimalPlaces == 1)
               return Optional.of(REDCapConstants.NUMBER_1_DECIMAL_PLACE_TEXTFIELD_VALIDATION);
             else if (decimalPlaces == 2)

--- a/src/test/java/org/metadatacenter/artifacts/model/core/NumericValueConstraintsTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/NumericValueConstraintsTest.java
@@ -32,6 +32,6 @@ public class NumericValueConstraintsTest
     assertEquals(unitOfMeasure, numericValueConstraints.unitOfMeasure().get());
     assertEquals(minValue, numericValueConstraints.minValue().get());
     assertEquals(maxValue, numericValueConstraints.maxValue().get());
-    assertEquals(decimalPlaces, numericValueConstraints.decimalPlaces().get());
+    assertEquals(decimalPlaces, numericValueConstraints.decimalPlace().get());
   }
 }

--- a/src/test/java/org/metadatacenter/artifacts/model/core/TemporalFieldUiTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/TemporalFieldUiTest.java
@@ -17,7 +17,7 @@ public class TemporalFieldUiTest
     TemporalFieldUi temporalFieldUi = TemporalFieldUi.builder()
       .withTemporalGranularity(temporalGranularity)
       .withInputTimeFormat(inputTimeFormat)
-      .withTimeZoneEnabled(timeZoneEnabled)
+      .withTimezoneEnabled(timeZoneEnabled)
       .withHidden(hidden)
       .build();
 
@@ -25,7 +25,7 @@ public class TemporalFieldUiTest
     assertEquals(FieldInputType.TEMPORAL, temporalFieldUi.inputType());
     assertEquals(temporalGranularity, temporalFieldUi.temporalGranularity());
     assertEquals(inputTimeFormat, temporalFieldUi.inputTimeFormat());
-    assertEquals(timeZoneEnabled, temporalFieldUi.timeZoneEnabled());
+    assertEquals(timeZoneEnabled, temporalFieldUi.timezoneEnabled());
     assertEquals(hidden, temporalFieldUi.hidden());
   }
 

--- a/src/test/java/org/metadatacenter/artifacts/model/core/builders/FieldSchemaArtifactBuilderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/builders/FieldSchemaArtifactBuilderTest.java
@@ -74,7 +74,7 @@ public class FieldSchemaArtifactBuilderTest
     Assert.assertEquals(maxValue, fieldSchemaArtifact.valueConstraints().get().asNumericValueConstraints().maxValue().get());
     Assert.assertEquals(maxValue, fieldSchemaArtifact.valueConstraints().get().asNumericValueConstraints().maxValue().get());
     Assert.assertEquals(unitOfMeasure, fieldSchemaArtifact.valueConstraints().get().asNumericValueConstraints().unitOfMeasure().get());
-    Assert.assertEquals(decimalPlaces, fieldSchemaArtifact.valueConstraints().get().asNumericValueConstraints().decimalPlaces().get());
+    Assert.assertEquals(decimalPlaces, fieldSchemaArtifact.valueConstraints().get().asNumericValueConstraints().decimalPlace().get());
   }
 
   @Test public void testCreateTemporalField()
@@ -84,7 +84,7 @@ public class FieldSchemaArtifactBuilderTest
     TemporalType temporalType = TemporalType.TIME;
     TemporalGranularity temporalGranularity = TemporalGranularity.SECOND;
     InputTimeFormat inputTimeFormat = InputTimeFormat.TWENTY_FOUR_HOUR;
-    boolean timeZoneEnabled = false;
+    boolean timezoneEnabled = false;
 
     FieldSchemaArtifact fieldSchemaArtifact = FieldSchemaArtifact.temporalFieldBuilder().
       withName(name).
@@ -92,7 +92,7 @@ public class FieldSchemaArtifactBuilderTest
       withTemporalType(temporalType).
       withTemporalGranularity(temporalGranularity).
       withInputTimeFormat(inputTimeFormat).
-      withTimeZoneEnabled(timeZoneEnabled).
+      withTimeZoneEnabled(timezoneEnabled).
       build();
 
     Assert.assertEquals(FieldInputType.TEMPORAL, fieldSchemaArtifact.fieldUi().inputType());
@@ -100,7 +100,7 @@ public class FieldSchemaArtifactBuilderTest
     Assert.assertEquals(description, fieldSchemaArtifact.description());
     Assert.assertEquals(temporalGranularity, fieldSchemaArtifact.fieldUi().asTemporalFieldUi().temporalGranularity());
     Assert.assertEquals(inputTimeFormat, fieldSchemaArtifact.fieldUi().asTemporalFieldUi().inputTimeFormat());
-    Assert.assertEquals(timeZoneEnabled, fieldSchemaArtifact.fieldUi().asTemporalFieldUi().timeZoneEnabled());
+    Assert.assertEquals(timezoneEnabled, fieldSchemaArtifact.fieldUi().asTemporalFieldUi().timezoneEnabled());
     Assert.assertEquals(temporalType, fieldSchemaArtifact.valueConstraints().get().asTemporalValueConstraints().temporalType());
   }
 

--- a/src/test/java/org/metadatacenter/artifacts/model/renderer/JsonSchemaArtifactRendererTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/renderer/JsonSchemaArtifactRendererTest.java
@@ -11,8 +11,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.metadatacenter.artifacts.model.core.FieldInputType;
 import org.metadatacenter.artifacts.model.core.FieldSchemaArtifact;
+import org.metadatacenter.artifacts.model.core.NumericType;
 import org.metadatacenter.artifacts.model.core.TemplateInstanceArtifact;
 import org.metadatacenter.artifacts.model.core.TemplateSchemaArtifact;
+import org.metadatacenter.artifacts.model.core.TemporalGranularity;
+import org.metadatacenter.artifacts.model.core.TemporalType;
 import org.metadatacenter.artifacts.model.reader.JsonSchemaArtifactReader;
 import org.metadatacenter.artifacts.model.reader.JsonSchemaArtifactReaderTest;
 
@@ -21,13 +24,20 @@ import java.io.IOException;
 import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.metadatacenter.model.ModelNodeNames.FIELD_SCHEMA_ARTIFACT_TYPE_IRI;
+import static org.metadatacenter.model.ModelNodeNames.JSON_LD_ID;
 import static org.metadatacenter.model.ModelNodeNames.JSON_LD_TYPE;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_FORMAT;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_OBJECT;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_SCHEMA;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_SCHEMA_IRI;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_TYPE;
+import static org.metadatacenter.model.ModelNodeNames.OSLC_MODIFIED_BY;
+import static org.metadatacenter.model.ModelNodeNames.PAV_CREATED_BY;
+import static org.metadatacenter.model.ModelNodeNames.PAV_CREATED_ON;
+import static org.metadatacenter.model.ModelNodeNames.PAV_LAST_UPDATED_ON;
 import static org.metadatacenter.model.ModelNodeNames.RDFS_LABEL;
 import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_DESCRIPTION;
 import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_NAME;
@@ -66,6 +76,83 @@ public class JsonSchemaArtifactRendererTest
     assertEquals(rendering.get(SCHEMA_ORG_NAME).textValue(), "Study");
   }
 
+  @Test public void testRenderTemporalField()
+  {
+    String fieldName = "Field name";
+    String fieldDescription = "Field description";
+    boolean requiredValue = false;
+    TemporalGranularity granularity = TemporalGranularity.DAY;
+    TemporalType temporalType = TemporalType.DATE;
+
+    FieldSchemaArtifact fieldSchemaArtifact = FieldSchemaArtifact.temporalFieldBuilder().
+            withName(fieldName).
+            withDescription(fieldDescription).
+            withRequiredValue(requiredValue).
+            withTemporalGranularity(granularity).
+            withTemporalType(temporalType).
+            build();
+
+    ObjectNode rendering = jsonSchemaArtifactRenderer.renderFieldSchemaArtifact(fieldSchemaArtifact);
+
+    assertTrue(validateJsonSchema(rendering));
+
+    assertEquals(rendering.get(JSON_SCHEMA_SCHEMA).textValue(), JSON_SCHEMA_SCHEMA_IRI);
+    assertEquals(rendering.get(JSON_SCHEMA_TYPE).textValue(), JSON_SCHEMA_OBJECT);
+    assertEquals(rendering.get(JSON_LD_TYPE).textValue(), FIELD_SCHEMA_ARTIFACT_TYPE_IRI);
+    assertEquals(rendering.get(SCHEMA_ORG_NAME).textValue(), fieldName);
+    assertEquals(rendering.get(SCHEMA_ORG_DESCRIPTION).textValue(), fieldDescription);
+    //assertEquals(rendering.get(VALUE_CONSTRAINTS).get(VALUE_CONSTRAINTS_DEFAULT_VALUE).get(VALUE_CONSTRAINTS_DEFAULT_VALUE).textValue(), defaultURI.toString());
+    // CEDAR requires the follow keys to be present, even if the values are null
+    assertTrue(rendering.has(PAV_CREATED_BY));
+    assertTrue(rendering.has(PAV_CREATED_ON));
+    assertTrue(rendering.has(PAV_LAST_UPDATED_ON));
+    assertTrue(rendering.has(OSLC_MODIFIED_BY));
+    assertTrue(rendering.has(JSON_LD_ID));
+    // catch potential error case where "requiredValue": false does not render
+    assertFalse(rendering.get("_valueConstraints").get("requiredValue").asBoolean());
+    assertEquals(rendering.get("_valueConstraints").get("temporalType").textValue(), temporalType.getText());
+    assertEquals(rendering.get("_ui").get("temporalGranularity").textValue(), granularity.getText());
+    assertTrue(rendering.get("_ui").has("timezoneEnabled"));
+  }
+
+  @Test public void testRenderNumericField()
+  {
+    String fieldName = "Field name";
+    String fieldDescription = "Field description";
+    boolean requiredValue = false;
+    NumericType numericType = NumericType.DECIMAL;
+    int decimalPlaces = 3;
+
+    FieldSchemaArtifact fieldSchemaArtifact = FieldSchemaArtifact.numericFieldBuilder().
+            withName(fieldName).
+            withDescription(fieldDescription).
+            withRequiredValue(requiredValue).
+            withNumericType(numericType).
+            withDecimalPlaces(decimalPlaces).
+            build();
+
+    ObjectNode rendering = jsonSchemaArtifactRenderer.renderFieldSchemaArtifact(fieldSchemaArtifact);
+
+    assertTrue(validateJsonSchema(rendering));
+
+    assertEquals(rendering.get(JSON_SCHEMA_SCHEMA).textValue(), JSON_SCHEMA_SCHEMA_IRI);
+    assertEquals(rendering.get(JSON_SCHEMA_TYPE).textValue(), JSON_SCHEMA_OBJECT);
+    assertEquals(rendering.get(JSON_LD_TYPE).textValue(), FIELD_SCHEMA_ARTIFACT_TYPE_IRI);
+    assertEquals(rendering.get(SCHEMA_ORG_NAME).textValue(), fieldName);
+    assertEquals(rendering.get(SCHEMA_ORG_DESCRIPTION).textValue(), fieldDescription);
+    //assertEquals(rendering.get(VALUE_CONSTRAINTS).get(VALUE_CONSTRAINTS_DEFAULT_VALUE).get(VALUE_CONSTRAINTS_DEFAULT_VALUE).textValue(), defaultURI.toString());
+    // CEDAR requires the follow keys to be present, even if the values are null
+    assertTrue(rendering.has(PAV_CREATED_BY));
+    assertTrue(rendering.has(PAV_CREATED_ON));
+    assertTrue(rendering.has(PAV_LAST_UPDATED_ON));
+    assertTrue(rendering.has(OSLC_MODIFIED_BY));
+    assertTrue(rendering.has(JSON_LD_ID));
+    // catch potential error case where "requiredValue": false does not render
+    assertFalse(rendering.get("_valueConstraints").get("requiredValue").asBoolean());
+    assertEquals(rendering.get("_valueConstraints").get("numberType").textValue(), numericType.getText());
+    assertEquals(rendering.get("_valueConstraints").get("decimalPlace").asInt(), decimalPlaces);
+  }
+
   @Test public void testRenderTextField()
   {
     String fieldName = "Field name";
@@ -88,6 +175,14 @@ public class JsonSchemaArtifactRendererTest
     assertEquals(rendering.get(SCHEMA_ORG_NAME).textValue(), fieldName);
     assertEquals(rendering.get(SCHEMA_ORG_DESCRIPTION).textValue(), fieldDescription);
     //assertEquals(rendering.get(VALUE_CONSTRAINTS).get(VALUE_CONSTRAINTS_DEFAULT_VALUE).get(VALUE_CONSTRAINTS_DEFAULT_VALUE).textValue(), defaultURI.toString());
+    // CEDAR requires the follow keys to be present, even if the values are null
+    assertTrue(rendering.has(PAV_CREATED_BY));
+    assertTrue(rendering.has(PAV_CREATED_ON));
+    assertTrue(rendering.has(PAV_LAST_UPDATED_ON));
+    assertTrue(rendering.has(OSLC_MODIFIED_BY));
+    assertTrue(rendering.has(JSON_LD_ID));
+    // catch potential error case where "requiredValue": false (default) does not render
+    assertFalse(rendering.get("_valueConstraints").get("requiredValue").asBoolean());
   }
 
   @Test public void testRenderLinkField()


### PR DESCRIPTION
Bugs fixed:
- `decimalPlaces` changed to `decimalPlace` for numeric field constraints
- `timeZoneEnabled` changed to `timezoneEnabled` for temporal fields
- include the following JSON fields required for CEDAR validation if they are null or not provided by the user:  `PAV_CREATED_BY`, `PAV_CREATED_ON`, `PAV_LAST_UPDATED_ON`, `OSLC_MODIFIED_BY`, `JSON_LD_ID`. These are required by CEDAR even if they have null values.
- changed `termUri` to `uri` for ArrayJsonSchemaTypeSpecification and JsonSchemaTypeSpecification. I left `termUri` as is where it shows up elsewhere because I'm not sure if this is a "find-and-replace" kind of fix. I haven't looked into whether `termUri` is actually correct in the other places it shows up, e.g., for the format specification of `pav`.
- always render `requiredValue` under `_valueConstraints`, as required by CEDAR. Because the primitive `boolean` type defaults to `false`, the `@JsonINclude(JsonInclude.Include.NON_DEFAULT)` annotation prevented the rendering of `false` values.

Also added unit testing on these rendering bugs.