### PR TITLE
Handle some common data errors

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/core/fields/DefaultValue.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/fields/DefaultValue.java
@@ -56,7 +56,7 @@ public sealed interface DefaultValue<T> permits TextDefaultValue, NumericDefault
       if (getValueType() == DefaultValueType.CONTROLLED_TERM)
          return (ControlledTermDefaultValue)this;
       else
-         throw new ClassCastException("Cannot convert " + this.getClass().getName() + " to " + ControlledTermDefaultValue.class.getName());
+         return null;
    }
 
    default TemporalDefaultValue asTemporalDefaultValue()


### PR DESCRIPTION
This PR handles some errors that we've seen in the data exported from preprod during our efforts to align the Java and TypeScript libraries:
- Auto-fix improper (but often seen) timezone offset of the form `+HHMM` (instead of the correct `+HH:MM`)
- If a controlled field has a defaultValue of a text field (not object with iri and rdfsLabel, just a text) silently treat it as no default value