### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,.codespellrc
+skip = .git*,.codespellrc,templates
 check-hidden = true
-# ignore-regex = 
+ignore-regex = \b(Convertor|CACL)\b
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Currently, CEDAR provides the following types of fields: text, temporal, numeric
 
 A class called `FieldSchemaArtifact` represents all of these field types.
 
-Since each field has specific characteristics, a custom builder is provided to contruct each field type.
+Since each field has specific characteristics, a custom builder is provided to construct each field type.
 
 ### Creating Text Fields
 
@@ -231,7 +231,7 @@ An example numeric field representing the percentage of a treatment completed an
 
 A builder supplied by a class called `TemporalField` can be used to create a CEDAR temporal fields.
 
-In CEDAR, temporal fields can represent a time value, a date value, and a datetime value. An enumerated type called `TemporalType` can be used to specify this type when creating a temporal field. Similarly, the desired granularity and whether a 12- or 24-hour presentation is desired can be opitionally be specified; an enumeration called `TemporalGranularity` can be used to specify the format, and an enumeration called `InputTimeFormat` for the latter. Finally, a temporal field may optionally be configured to display time zone information.
+In CEDAR, temporal fields can represent a time value, a date value, and a datetime value. An enumerated type called `TemporalType` can be used to specify this type when creating a temporal field. Similarly, the desired granularity and whether a 12- or 24-hour presentation is desired can be optionally be specified; an enumeration called `TemporalGranularity` can be used to specify the format, and an enumeration called `InputTimeFormat` for the latter. Finally, a temporal field may optionally be configured to display time zone information.
 
 An example temporal field representing the time of a patient visit recorded with the accuracy of minutes and presented in 24-hour format with time zone information displayed could be created as follows:
 

--- a/src/main/java/org/metadatacenter/artifacts/model/reader/JsonArtifactReader.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/reader/JsonArtifactReader.java
@@ -959,7 +959,7 @@ public class JsonArtifactReader implements ArtifactReader<ObjectNode>
           Optional.of(defaultValue.get().asNumericDefaultValue()) :
           Optional.empty();
         if (!numberType.isPresent())
-          numberType = Optional.of(XsdNumericDatatype.DECIMAL); // Default to xsd:decimal if unspecifed
+          numberType = Optional.of(XsdNumericDatatype.DECIMAL); // Default to xsd:decimal if unspecified
         return Optional.of(
           NumericValueConstraints.create(numberType.get(), minValue, maxValue, decimalPlaces, unitOfMeasure,
             numericDefaultValue, requiredValue, recommendedValue, multipleChoice));
@@ -1926,7 +1926,7 @@ public class JsonArtifactReader implements ArtifactReader<ObjectNode>
   {
     Version artifactModelVersion = readModelVersion(sourceNode, path);
 
-    // TODO Renable eventually after patching older artifacts
+    // TODO Re-enable eventually after patching older artifacts
     //    if (!artifactModelVersion.equals(modelVersion))
     //      throw new ArtifactParseException("Expecting model version " + modelVersion + ", got " + artifactModelVersion,
     //        SCHEMA_ORG_SCHEMA_VERSION, path);

--- a/src/main/java/org/metadatacenter/artifacts/model/tools/Templates2Ubkg.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/tools/Templates2Ubkg.java
@@ -33,7 +33,7 @@ public class Templates2Ubkg
   private static final String TEMPLATE_FILE_OPTION = "f";
   private static final String TEMPLATE_IRI_OPTION = "i";
   private static final String UBKG_NODE_FILE_OPTION = "un";
-  private static final String UBKG_EDGE_FILE_OPTION = "ue";
+  private static final String UBKG_EDGE_FILE_OPTION = "ue";  # codespell:ignore
   private static final String CEDAR_RESOURCE_BASE_OPTION = "r";
   private static final String CEDAR_APIKEY_OPTION = "k";
   private static final String JSON_FILE_EXTENSION = ".json";


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.