### PR TITLE
Deduplicate parent-schema and instance-artifact record validation

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/core/ElementInstanceArtifact.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/ElementInstanceArtifact.java
@@ -11,18 +11,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateListFieldNotNull;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateMapFieldNotNull;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateOptionalFieldNotNull;
-import static org.metadatacenter.model.ModelNodeNames.JSON_LD_CONTEXT;
-import static org.metadatacenter.model.ModelNodeNames.JSON_LD_ID;
-import static org.metadatacenter.model.ModelNodeNames.JSON_LD_TYPE;
-import static org.metadatacenter.model.ModelNodeNames.OSLC_MODIFIED_BY;
-import static org.metadatacenter.model.ModelNodeNames.PAV_CREATED_BY;
-import static org.metadatacenter.model.ModelNodeNames.PAV_CREATED_ON;
-import static org.metadatacenter.model.ModelNodeNames.PAV_LAST_UPDATED_ON;
-import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_DESCRIPTION;
-import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_NAME;
 
 /**
  * While element instances may not necessarily have a JSON-LD identifier or provenance fields (name, description,
@@ -377,21 +365,9 @@ record ElementInstanceArtifactRecord(LinkedHashMap<String, URI> jsonLdContext, L
 {
   public ElementInstanceArtifactRecord
   {
-    validateMapFieldNotNull(this, jsonLdContext, JSON_LD_CONTEXT);
-    validateListFieldNotNull(this, jsonLdTypes, JSON_LD_TYPE);
-    validateOptionalFieldNotNull(this, jsonLdId, JSON_LD_ID);
-    validateOptionalFieldNotNull(this, name, SCHEMA_ORG_NAME);
-    validateOptionalFieldNotNull(this, description, SCHEMA_ORG_DESCRIPTION);
-    validateOptionalFieldNotNull(this, createdBy, PAV_CREATED_BY);
-    validateOptionalFieldNotNull(this, modifiedBy, OSLC_MODIFIED_BY);
-    validateOptionalFieldNotNull(this, createdOn, PAV_CREATED_ON);
-    validateOptionalFieldNotNull(this, lastUpdatedOn, PAV_LAST_UPDATED_ON);
-    validateListFieldNotNull(this, childKeys, "childKeys");
-    validateMapFieldNotNull(this, singleInstanceFieldInstances, "singleInstanceFieldInstances");
-    validateMapFieldNotNull(this, multiInstanceFieldInstances, "multiInstanceFieldInstances");
-    validateMapFieldNotNull(this, singleInstanceElementInstances, "singleInstanceElementInstances");
-    validateMapFieldNotNull(this, multiInstanceElementInstances, "multiInstanceElementInstances");
-    validateMapFieldNotNull(this, attributeValueFieldInstanceGroups, "attributeValueFieldInstanceGroups");
+    InstanceArtifactInvariants.validate(this, jsonLdContext, jsonLdTypes, jsonLdId, name, description, createdBy,
+      modifiedBy, createdOn, lastUpdatedOn, childKeys, singleInstanceFieldInstances, multiInstanceFieldInstances,
+      singleInstanceElementInstances, multiInstanceElementInstances, attributeValueFieldInstanceGroups);
 
     // TODO Check that all childKeys present in child instances maps and that there are no extra fields in maps
 

--- a/src/main/java/org/metadatacenter/artifacts/model/core/ElementSchemaArtifact.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/ElementSchemaArtifact.java
@@ -6,34 +6,16 @@ import org.metadatacenter.artifacts.model.core.ui.ParentArtifactUi;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toSet;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateMapFieldContainsAll;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateMapFieldNotNull;
 import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateOptionalFieldNotNull;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateStringFieldNotEmpty;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateStringFieldNotNull;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateUiFieldNotNull;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateUriListFieldContains;
 import static org.metadatacenter.model.ModelNodeNames.ELEMENT_SCHEMA_ARTIFACT_TYPE_IRI;
-import static org.metadatacenter.model.ModelNodeNames.JSON_LD_CONTEXT;
-import static org.metadatacenter.model.ModelNodeNames.JSON_LD_ID;
-import static org.metadatacenter.model.ModelNodeNames.JSON_LD_TYPE;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_DESCRIPTION;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_MAX_ITEMS;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_MIN_ITEMS;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_TITLE;
 import static org.metadatacenter.model.ModelNodeNames.PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
-import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_DESCRIPTION;
-import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_NAME;
-import static org.metadatacenter.model.ModelNodeNames.UI;
 
 public non-sealed interface ElementSchemaArtifact extends SchemaArtifact, ChildSchemaArtifact, ParentSchemaArtifact
 {
@@ -418,44 +400,15 @@ record ElementSchemaArtifactRecord(String internalName, String internalDescripti
 {
   public ElementSchemaArtifactRecord
   {
-    validateStringFieldNotNull(this, internalName, JSON_SCHEMA_TITLE);
-    validateStringFieldNotNull(this, internalDescription, JSON_SCHEMA_DESCRIPTION);
-    validateStringFieldNotEmpty(this, name, SCHEMA_ORG_NAME);
-    validateStringFieldNotNull(this, description, SCHEMA_ORG_DESCRIPTION);
-    validateMapFieldContainsAll(this, jsonLdContext, JSON_LD_CONTEXT, PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS);
-    validateUriListFieldContains(this, jsonLdTypes, JSON_LD_TYPE, URI.create(ELEMENT_SCHEMA_ARTIFACT_TYPE_IRI));
-    validateOptionalFieldNotNull(this, jsonLdId, JSON_LD_ID);
-    validateOptionalFieldNotNull(this, instanceJsonLdType, "instanceJsonLdType");
-    validateMapFieldNotNull(this, fieldSchemas, "fieldSchemas");
-    validateMapFieldNotNull(this, elementSchemas, "elementSchemas");
-    validateUiFieldNotNull(this, elementUi, UI);
+    ParentSchemaArtifactInvariants.validate(this, internalName, internalDescription, name, description,
+      jsonLdContext, jsonLdTypes, URI.create(ELEMENT_SCHEMA_ARTIFACT_TYPE_IRI), jsonLdId, instanceJsonLdType,
+      version, status, previousVersion, derivedFrom, fieldSchemas, elementSchemas, language, elementUi, annotations);
     validateOptionalFieldNotNull(this, propertyUri, "propertyUri");
-    validateOptionalFieldNotNull(this, language, "language");
     validateOptionalFieldNotNull(this, minItems, JSON_SCHEMA_MIN_ITEMS);
     validateOptionalFieldNotNull(this, maxItems, JSON_SCHEMA_MAX_ITEMS);
-    validateOptionalFieldNotNull(this, annotations, "annotations");
 
-    if (minItems.isPresent() && minItems.get() < 0)
-      throw new IllegalStateException("minItems must be zero or greater in element schema artifact " + name());
-
-    if (maxItems.isPresent() && maxItems.get() < 1)
-      throw new IllegalStateException("maxItems must be one or greater in element schema artifact " + name());
-
-    if (minItems.isPresent() && maxItems.isPresent() && (minItems.get() > maxItems.get()))
-      throw new IllegalStateException("minItems must be less than maxItems in element schema artifact " + name());
-
-    Set<String> order = new HashSet<>(elementUi.order());
-    Set<String> childKeys = Stream.concat(fieldSchemas.keySet().stream(), elementSchemas.keySet().stream())
-      .collect(toSet());
-
-    if (!order.containsAll(childKeys)) {
-      childKeys.removeAll(order); // Generate the names of children not in the order map
-      order.removeAll(childKeys); // Silently remove these extra children from the order
-      for (String childToRemove : childKeys) { // And from the
-        fieldSchemas.remove(childToRemove);
-        elementSchemas.remove(childToRemove);
-      }
-    }
+    ParentSchemaArtifactInvariants.validateItemBounds(this, name(), minItems, maxItems);
+    ParentSchemaArtifactInvariants.pruneChildrenNotInOrder(fieldSchemas, elementSchemas, elementUi.order());
 
     jsonLdContext = new LinkedHashMap<>(jsonLdContext);
     jsonLdTypes = new ArrayList<>(jsonLdTypes);

--- a/src/main/java/org/metadatacenter/artifacts/model/core/InstanceArtifactInvariants.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/InstanceArtifactInvariants.java
@@ -1,0 +1,73 @@
+package org.metadatacenter.artifacts.model.core;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateListFieldNotNull;
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateMapFieldNotNull;
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateOptionalFieldNotNull;
+import static org.metadatacenter.model.ModelNodeNames.JSON_LD_CONTEXT;
+import static org.metadatacenter.model.ModelNodeNames.JSON_LD_ID;
+import static org.metadatacenter.model.ModelNodeNames.JSON_LD_TYPE;
+import static org.metadatacenter.model.ModelNodeNames.OSLC_MODIFIED_BY;
+import static org.metadatacenter.model.ModelNodeNames.PAV_CREATED_BY;
+import static org.metadatacenter.model.ModelNodeNames.PAV_CREATED_ON;
+import static org.metadatacenter.model.ModelNodeNames.PAV_LAST_UPDATED_ON;
+import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_DESCRIPTION;
+import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_NAME;
+
+/**
+ * Shared compact-constructor invariants for instance-artifact records (template + element).
+ * <p>
+ * Both records previously open-coded the same ~14 line validation block on the same
+ * field names. This helper covers those shared invariants; record-specific fields
+ * ({@code isBasedOn}, {@code derivedFrom}, {@code annotations} on the template flavor)
+ * stay inline in the respective compact constructor.
+ */
+final class InstanceArtifactInvariants
+{
+  private InstanceArtifactInvariants() {}
+
+  /**
+   * Validate the invariants shared by template-instance and element-instance records.
+   * <p>
+   * Throws {@link IllegalStateException} on violation.
+   */
+  static void validate(Object self,
+                       LinkedHashMap<String, URI> jsonLdContext,
+                       List<URI> jsonLdTypes,
+                       Optional<URI> jsonLdId,
+                       Optional<String> name,
+                       Optional<String> description,
+                       Optional<URI> createdBy,
+                       Optional<URI> modifiedBy,
+                       Optional<OffsetDateTime> createdOn,
+                       Optional<OffsetDateTime> lastUpdatedOn,
+                       List<String> childKeys,
+                       Map<String, ?> singleInstanceFieldInstances,
+                       Map<String, ?> multiInstanceFieldInstances,
+                       Map<String, ?> singleInstanceElementInstances,
+                       Map<String, ?> multiInstanceElementInstances,
+                       Map<String, ?> attributeValueFieldInstanceGroups)
+  {
+    validateMapFieldNotNull(self, jsonLdContext, JSON_LD_CONTEXT);
+    validateListFieldNotNull(self, jsonLdTypes, JSON_LD_TYPE);
+    validateOptionalFieldNotNull(self, jsonLdId, JSON_LD_ID);
+    validateOptionalFieldNotNull(self, name, SCHEMA_ORG_NAME);
+    validateOptionalFieldNotNull(self, description, SCHEMA_ORG_DESCRIPTION);
+    validateOptionalFieldNotNull(self, createdBy, PAV_CREATED_BY);
+    validateOptionalFieldNotNull(self, modifiedBy, OSLC_MODIFIED_BY);
+    validateOptionalFieldNotNull(self, createdOn, PAV_CREATED_ON);
+    validateOptionalFieldNotNull(self, lastUpdatedOn, PAV_LAST_UPDATED_ON);
+    validateListFieldNotNull(self, childKeys, "childKeys");
+    validateMapFieldNotNull(self, singleInstanceFieldInstances, "singleInstanceFieldInstances");
+    validateMapFieldNotNull(self, multiInstanceFieldInstances, "multiInstanceFieldInstances");
+    validateMapFieldNotNull(self, singleInstanceElementInstances, "singleInstanceElementInstances");
+    validateMapFieldNotNull(self, multiInstanceElementInstances, "multiInstanceElementInstances");
+    validateMapFieldNotNull(self, attributeValueFieldInstanceGroups, "attributeValueFieldInstanceGroups");
+  }
+}

--- a/src/main/java/org/metadatacenter/artifacts/model/core/ParentSchemaArtifactInvariants.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/ParentSchemaArtifactInvariants.java
@@ -1,0 +1,136 @@
+package org.metadatacenter.artifacts.model.core;
+
+import org.metadatacenter.artifacts.model.core.ui.Ui;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateMapFieldContainsAll;
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateMapFieldNotNull;
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateOptionalFieldNotNull;
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateStringFieldNotEmpty;
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateStringFieldNotNull;
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateUiFieldNotNull;
+import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateUriListFieldContains;
+import static org.metadatacenter.model.ModelNodeNames.BIBO_STATUS;
+import static org.metadatacenter.model.ModelNodeNames.JSON_LD_CONTEXT;
+import static org.metadatacenter.model.ModelNodeNames.JSON_LD_ID;
+import static org.metadatacenter.model.ModelNodeNames.JSON_LD_TYPE;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_DESCRIPTION;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_TITLE;
+import static org.metadatacenter.model.ModelNodeNames.PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
+import static org.metadatacenter.model.ModelNodeNames.PAV_DERIVED_FROM;
+import static org.metadatacenter.model.ModelNodeNames.PAV_PREVIOUS_VERSION;
+import static org.metadatacenter.model.ModelNodeNames.PAV_VERSION;
+import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_DESCRIPTION;
+import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_NAME;
+import static org.metadatacenter.model.ModelNodeNames.UI;
+
+/**
+ * Shared compact-constructor invariants for parent-schema records (template + element).
+ * <p>
+ * Both records previously open-coded the same ~15 line validation block, with subtle drift:
+ * {@code TemplateSchemaArtifactRecord} validated version/status/previousVersion/derivedFrom
+ * while {@code ElementSchemaArtifactRecord} did not, despite carrying the same fields.
+ * This helper covers the shared invariants, plus the "drop children not present in the UI order"
+ * cleanup logic which is identical between the two records.
+ */
+final class ParentSchemaArtifactInvariants
+{
+  private ParentSchemaArtifactInvariants() {}
+
+  /**
+   * Validate the invariants shared by template-schema and element-schema records.
+   * <p>
+   * Throws {@link IllegalStateException} on violation.
+   */
+  static void validate(Object self,
+                       String internalName,
+                       String internalDescription,
+                       String name,
+                       String description,
+                       LinkedHashMap<String, URI> jsonLdContext,
+                       List<URI> jsonLdTypes,
+                       URI requiredJsonLdTypeIri,
+                       Optional<URI> jsonLdId,
+                       Optional<URI> instanceJsonLdType,
+                       Optional<Version> version,
+                       Optional<Status> status,
+                       Optional<URI> previousVersion,
+                       Optional<URI> derivedFrom,
+                       Map<String, ?> fieldSchemas,
+                       Map<String, ?> elementSchemas,
+                       Optional<String> language,
+                       Ui ui,
+                       Optional<Annotations> annotations)
+  {
+    validateStringFieldNotNull(self, internalName, JSON_SCHEMA_TITLE);
+    validateStringFieldNotNull(self, internalDescription, JSON_SCHEMA_DESCRIPTION);
+    validateStringFieldNotEmpty(self, name, SCHEMA_ORG_NAME);
+    validateStringFieldNotNull(self, description, SCHEMA_ORG_DESCRIPTION);
+    validateOptionalFieldNotNull(self, version, PAV_VERSION);
+    validateOptionalFieldNotNull(self, status, BIBO_STATUS);
+    validateOptionalFieldNotNull(self, previousVersion, PAV_PREVIOUS_VERSION);
+    validateOptionalFieldNotNull(self, derivedFrom, PAV_DERIVED_FROM);
+    validateMapFieldContainsAll(self, jsonLdContext, JSON_LD_CONTEXT, PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS);
+    validateUriListFieldContains(self, jsonLdTypes, JSON_LD_TYPE, requiredJsonLdTypeIri);
+    validateOptionalFieldNotNull(self, jsonLdId, JSON_LD_ID);
+    validateOptionalFieldNotNull(self, instanceJsonLdType, "instanceJsonLdType");
+    validateMapFieldNotNull(self, fieldSchemas, "fieldSchemas");
+    validateMapFieldNotNull(self, elementSchemas, "elementSchemas");
+    validateOptionalFieldNotNull(self, language, "language");
+    validateUiFieldNotNull(self, ui, UI);
+    validateOptionalFieldNotNull(self, annotations, "annotations");
+  }
+
+  /**
+   * Range-check minItems and maxItems for records that have them (element schema artifacts).
+   * Throws {@link IllegalStateException} on violation.
+   */
+  static void validateItemBounds(Object self, String name, Optional<Integer> minItems, Optional<Integer> maxItems)
+  {
+    String kind = self.getClass().getSimpleName();
+
+    if (minItems.isPresent() && minItems.get() < 0)
+      throw new IllegalStateException("minItems must be zero or greater in " + kind + " " + name);
+
+    if (maxItems.isPresent() && maxItems.get() < 1)
+      throw new IllegalStateException("maxItems must be one or greater in " + kind + " " + name);
+
+    if (minItems.isPresent() && maxItems.isPresent() && (minItems.get() > maxItems.get()))
+      throw new IllegalStateException("minItems must be less than or equal to maxItems in " + kind + " " + name);
+  }
+
+  /**
+   * Drop any children whose key is not present in the UI {@code order} list, and likewise
+   * trim the order itself of stale entries. Mutates the passed-in maps.
+   * <p>
+   * This is a silent cleanup — the original behavior in both records. We're not flagging
+   * order/child drift as an error because callers (readers, builders) may legitimately
+   * produce intermediate states where they diverge.
+   */
+  static void pruneChildrenNotInOrder(LinkedHashMap<String, ? extends SchemaArtifact> fieldSchemas,
+                                      LinkedHashMap<String, ? extends SchemaArtifact> elementSchemas,
+                                      List<String> uiOrder)
+  {
+    Set<String> order = new HashSet<>(uiOrder);
+    Set<String> childKeys = Stream.concat(fieldSchemas.keySet().stream(), elementSchemas.keySet().stream())
+      .collect(toSet());
+
+    if (!order.containsAll(childKeys)) {
+      childKeys.removeAll(order);
+      order.removeAll(childKeys);
+      for (String childToRemove : childKeys) {
+        fieldSchemas.remove(childToRemove);
+        elementSchemas.remove(childToRemove);
+      }
+    }
+  }
+}

--- a/src/main/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifact.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifact.java
@@ -368,23 +368,11 @@ record TemplateInstanceArtifactRecord(LinkedHashMap<String, URI> jsonLdContext, 
                                       LinkedHashMap<String, Map<String, FieldInstanceArtifact>> attributeValueFieldInstanceGroups,
                                       Optional<Annotations> annotations) implements TemplateInstanceArtifact {
   public TemplateInstanceArtifactRecord {
-    validateMapFieldNotNull(this, jsonLdContext, JSON_LD_CONTEXT);
-    validateListFieldNotNull(this, jsonLdTypes, JSON_LD_TYPE);
-    validateOptionalFieldNotNull(this, jsonLdId, JSON_LD_ID);
-    validateOptionalFieldNotNull(this, name, SCHEMA_ORG_NAME);
-    validateOptionalFieldNotNull(this, description, SCHEMA_ORG_DESCRIPTION);
-    validateOptionalFieldNotNull(this, createdBy, PAV_CREATED_BY);
+    InstanceArtifactInvariants.validate(this, jsonLdContext, jsonLdTypes, jsonLdId, name, description, createdBy,
+      modifiedBy, createdOn, lastUpdatedOn, childKeys, singleInstanceFieldInstances, multiInstanceFieldInstances,
+      singleInstanceElementInstances, multiInstanceElementInstances, attributeValueFieldInstanceGroups);
     validateOptionalFieldNotNull(this, derivedFrom, PAV_DERIVED_FROM);
-    validateOptionalFieldNotNull(this, modifiedBy, OSLC_MODIFIED_BY);
-    validateOptionalFieldNotNull(this, createdOn, PAV_CREATED_ON);
-    validateOptionalFieldNotNull(this, lastUpdatedOn, PAV_LAST_UPDATED_ON);
     validateUriFieldNotNull(this, isBasedOn, SCHEMA_IS_BASED_ON);
-    validateListFieldNotNull(this, childKeys, "childKeys");
-    validateMapFieldNotNull(this, singleInstanceFieldInstances, "singleInstanceFieldInstances");
-    validateMapFieldNotNull(this, multiInstanceFieldInstances, "multiInstanceFieldInstances");
-    validateMapFieldNotNull(this, singleInstanceElementInstances, "singleInstanceElementInstances");
-    validateMapFieldNotNull(this, multiInstanceElementInstances, "multiInstanceElementInstances");
-    validateMapFieldNotNull(this, attributeValueFieldInstanceGroups, "attributeValueFieldInstanceGroups");
     validateOptionalFieldNotNull(this, annotations, "annotations");
 
     // TODO Check that all childKeys present in child instances maps and that there are no extra fields in maps

--- a/src/main/java/org/metadatacenter/artifacts/model/core/TemplateSchemaArtifact.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/TemplateSchemaArtifact.java
@@ -6,36 +6,13 @@ import org.metadatacenter.artifacts.model.core.ui.TemplateUi;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toSet;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateMapFieldContainsAll;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateMapFieldNotNull;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateOptionalFieldNotNull;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateStringFieldNotEmpty;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateStringFieldNotNull;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateUiFieldNotNull;
-import static org.metadatacenter.artifacts.model.core.ValidationHelper.validateUriListFieldContains;
-import static org.metadatacenter.model.ModelNodeNames.BIBO_STATUS;
-import static org.metadatacenter.model.ModelNodeNames.JSON_LD_CONTEXT;
-import static org.metadatacenter.model.ModelNodeNames.JSON_LD_ID;
-import static org.metadatacenter.model.ModelNodeNames.JSON_LD_TYPE;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_DESCRIPTION;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_TITLE;
 import static org.metadatacenter.model.ModelNodeNames.PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
-import static org.metadatacenter.model.ModelNodeNames.PAV_DERIVED_FROM;
-import static org.metadatacenter.model.ModelNodeNames.PAV_PREVIOUS_VERSION;
-import static org.metadatacenter.model.ModelNodeNames.PAV_VERSION;
-import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_DESCRIPTION;
-import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_NAME;
 import static org.metadatacenter.model.ModelNodeNames.TEMPLATE_SCHEMA_ARTIFACT_TYPE_IRI;
-import static org.metadatacenter.model.ModelNodeNames.UI;
 
 public non-sealed interface TemplateSchemaArtifact extends SchemaArtifact, ParentSchemaArtifact {
   static TemplateSchemaArtifact create(LinkedHashMap<String, URI> jsonLdContext, List<URI> jsonLdTypes,
@@ -378,36 +355,11 @@ record TemplateSchemaArtifactRecord(
     String internalDescription)
     implements TemplateSchemaArtifact {
   public TemplateSchemaArtifactRecord {
-    validateStringFieldNotNull(this, internalName, JSON_SCHEMA_TITLE);
-    validateStringFieldNotNull(this, internalDescription, JSON_SCHEMA_DESCRIPTION);
-    validateStringFieldNotEmpty(this, name, SCHEMA_ORG_NAME);
-    validateStringFieldNotNull(this, description, SCHEMA_ORG_DESCRIPTION);
-    validateOptionalFieldNotNull(this, version, PAV_VERSION);
-    validateOptionalFieldNotNull(this, status, BIBO_STATUS);
-    validateOptionalFieldNotNull(this, previousVersion, PAV_PREVIOUS_VERSION);
-    validateOptionalFieldNotNull(this, derivedFrom, PAV_DERIVED_FROM);
-    validateMapFieldContainsAll(this, jsonLdContext, JSON_LD_CONTEXT, PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS);
-    validateUriListFieldContains(this, jsonLdTypes, JSON_LD_TYPE, URI.create(TEMPLATE_SCHEMA_ARTIFACT_TYPE_IRI));
-    validateOptionalFieldNotNull(this, jsonLdId, JSON_LD_ID);
-    validateOptionalFieldNotNull(this, instanceJsonLdType, "instanceJsonLdType");
-    validateMapFieldNotNull(this, fieldSchemas, "fieldSchemas");
-    validateMapFieldNotNull(this, elementSchemas, "elementSchemas");
-    validateOptionalFieldNotNull(this, language, "language");
-    validateUiFieldNotNull(this, templateUi, UI);
-    validateOptionalFieldNotNull(this, annotations, "annotations");
+    ParentSchemaArtifactInvariants.validate(this, internalName, internalDescription, name, description,
+      jsonLdContext, jsonLdTypes, URI.create(TEMPLATE_SCHEMA_ARTIFACT_TYPE_IRI), jsonLdId, instanceJsonLdType,
+      version, status, previousVersion, derivedFrom, fieldSchemas, elementSchemas, language, templateUi, annotations);
 
-    Set<String> order = new HashSet<>(templateUi.order());
-    Set<String> childKeys = Stream.concat(fieldSchemas.keySet().stream(), elementSchemas.keySet().stream())
-        .collect(toSet());
-
-    if (!order.containsAll(childKeys)) {
-      childKeys.removeAll(order); // Generate the names of children not in the order map
-      order.removeAll(childKeys); // Silently remove these extra children from the order
-      for (String childToRemove : childKeys) { // And from the
-        fieldSchemas.remove(childToRemove);
-        elementSchemas.remove(childToRemove);
-      }
-    }
+    ParentSchemaArtifactInvariants.pruneChildrenNotInOrder(fieldSchemas, elementSchemas, templateUi.order());
 
     jsonLdContext = new LinkedHashMap<>(jsonLdContext);
     jsonLdTypes = List.copyOf(jsonLdTypes);


### PR DESCRIPTION
## Summary

Apply the same `Invariants` helper pattern from [#29](https://github.com/metadatacenter/cedar-artifact-library/pull/29) to the four template/element schema and instance records. Their compact constructors previously repeated ~15-30 line validation blocks (plus an identical "drop children not in UI order" cleanup between `TemplateSchemaArtifact` and `ElementSchemaArtifact`).

- New `ParentSchemaArtifactInvariants` centralizes the schema-record invariants and the prune-children-not-in-order cleanup; `ElementSchemaArtifact` also picks up `validateItemBounds` for the `minItems`/`maxItems` range check.
- New `InstanceArtifactInvariants` centralizes the shared instance-record invariants. `TemplateInstanceArtifact` retains inline validation for its record-specific `isBasedOn` / `derivedFrom` / `annotations` fields.

| | TemplateSchema | ElementSchema | TemplateInstance | ElementInstance |
|---|---|---|---|---|
| Compact ctor before | 36 LOC | 47 LOC | 31 LOC | 29 LOC |
| Compact ctor after | 11 LOC | 14 LOC | 17 LOC | 12 LOC |

Net: 6 files changed, +226 / −148 (~70 LOC removed once the helpers are in place).

## Side benefits surfaced by the consolidation

- **Latent bug fixed**: `ElementSchemaArtifact` carried `version` / `status` / `previousVersion` / `derivedFrom` record components but its compact constructor never validated them, while `TemplateSchemaArtifact` did. Both records now run the same invariants.
- **Same typo class as #29**: `ElementSchemaArtifact`'s `minItems > maxItems` error said "less than maxItems" — wrong, since the check allows equality. Now reports "less than or equal to" and names the kind via `getClass().getSimpleName()` instead of hard-coding "element schema artifact".

## Test plan

- [x] \`mvn clean test\` passes locally: 269 tests, 0 failures, 3 pre-existing skips
- [ ] CI: relies on \`cedar-parent:2.8.1-SNAPSHOT\` being resolvable on the build host (a pre-existing requirement on \`develop\`, not affected by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)