### PR TITLE
Migrate test suite from JUnit 4 to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,9 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/test/java/org/metadatacenter/artifacts/model/JsonArtifactRoundTripTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/JsonArtifactRoundTripTest.java
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.*;
 import org.metadatacenter.artifacts.model.core.fields.InputTimeFormat;
 import org.metadatacenter.artifacts.model.core.fields.TemporalGranularity;
@@ -26,8 +26,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.metadatacenter.artifacts.model.core.fields.constraints.ValueConstraintsActionType.DELETE;
 
 public class JsonArtifactRoundTripTest
@@ -37,7 +37,7 @@ public class JsonArtifactRoundTripTest
   private ObjectMapper mapper;
   private ModelValidator cedarModelValidator;
 
-  @Before public void setUp()
+  @BeforeEach public void setUp()
   {
     artifactReader = new JsonArtifactReader();
     jsonArtifactRenderer = new JsonArtifactRenderer();
@@ -314,7 +314,7 @@ public class JsonArtifactRoundTripTest
 
   // Can add attribute-value to literalFieldUIContent.json in meta model but then it complains about missing
   // valueConstraints
-  @Ignore // Fix standalone attribute-value field
+  @Disabled // Fix standalone attribute-value field
   @Test public void testRoundTripAttributeValueField()
   {
     String name = "Field name";

--- a/src/test/java/org/metadatacenter/artifacts/model/YamlArtifactRoundTripTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/YamlArtifactRoundTripTest.java
@@ -1,8 +1,8 @@
 package org.metadatacenter.artifacts.model;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.ElementSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.FieldSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.TemplateSchemaArtifact;
@@ -13,14 +13,14 @@ import org.metadatacenter.artifacts.model.renderer.YamlArtifactRenderer;
 import java.net.URI;
 import java.util.LinkedHashMap;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class YamlArtifactRoundTripTest
 {
   private YamlArtifactReader yamlArtifactReader = new YamlArtifactReader();
   private YamlArtifactRenderer yamlArtifactRenderer;
 
-  @Before public void setUp()
+  @BeforeEach public void setUp()
   {
     yamlArtifactReader = new YamlArtifactReader();
     yamlArtifactRenderer = new YamlArtifactRenderer(false);
@@ -43,7 +43,7 @@ public class YamlArtifactRoundTripTest
   }
 
   // TODO Need to activate this
-  @Ignore @Test public void testRoundTripTextField()
+  @Disabled @Test public void testRoundTripTextField()
   {
     TextField originalFieldSchemaArtifact = TextField.builder()
       .withJsonLdId(URI.create("https://repo.metadatacenter.org/template_fields/123")).withName("Study")

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ControlledTermValueConstraintsActionTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ControlledTermValueConstraintsActionTest.java
@@ -1,6 +1,6 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ControlledTermValueConstraintsAction;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ValueConstraintsActionType;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ValueType;
@@ -8,7 +8,7 @@ import org.metadatacenter.artifacts.model.core.fields.constraints.ValueType;
 import java.net.URI;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ControlledTermValueConstraintsActionTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ElementSchemaArtifactTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ElementSchemaArtifactTest.java
@@ -1,7 +1,7 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.ui.ElementUi;
 
 import java.net.URI;
@@ -11,8 +11,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.metadatacenter.model.ModelNodeNames.ELEMENT_SCHEMA_ARTIFACT_TYPE_IRI;
 import static org.metadatacenter.model.ModelNodeNames.PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
 
@@ -49,25 +49,25 @@ public class ElementSchemaArtifactTest
       Optional.of(createdOn), Optional.of(lastUpdatedOn), new LinkedHashMap<>(), new LinkedHashMap<>(), false, minItems,
       maxItems, propertyUri, language, ElementUi.builder().build(), Optional.empty());
 
-    Assert.assertEquals(jsonLdTypes, elementSchemaArtifact.jsonLdTypes());
-    Assert.assertEquals(jsonLdId, elementSchemaArtifact.jsonLdId().get());
-    Assert.assertEquals(instanceJsonLdType, elementSchemaArtifact.instanceJsonLdType().get());
-    Assert.assertEquals(jsonLdContext, elementSchemaArtifact.jsonLdContext());
-    Assert.assertEquals(createdBy, elementSchemaArtifact.createdBy().get());
-    Assert.assertEquals(modifiedBy, elementSchemaArtifact.modifiedBy().get());
-    Assert.assertEquals(createdOn, elementSchemaArtifact.createdOn().get());
-    Assert.assertEquals(lastUpdatedOn, elementSchemaArtifact.lastUpdatedOn().get());
-    Assert.assertEquals(internalName, elementSchemaArtifact.internalName());
-    Assert.assertEquals(internalDescription, elementSchemaArtifact.internalDescription());
-    Assert.assertEquals(name, elementSchemaArtifact.name());
-    Assert.assertEquals(description, elementSchemaArtifact.description());
-    Assert.assertEquals(identifier, elementSchemaArtifact.identifier());
-    Assert.assertEquals(version, elementSchemaArtifact.version());
-    Assert.assertEquals(status, elementSchemaArtifact.status());
-    Assert.assertEquals(previousVersion, elementSchemaArtifact.previousVersion());
-    Assert.assertEquals(derivedFrom, elementSchemaArtifact.derivedFrom());
-    Assert.assertEquals(propertyUri, elementSchemaArtifact.propertyUri());
-    Assert.assertEquals(language, elementSchemaArtifact.language());
+    Assertions.assertEquals(jsonLdTypes, elementSchemaArtifact.jsonLdTypes());
+    Assertions.assertEquals(jsonLdId, elementSchemaArtifact.jsonLdId().get());
+    Assertions.assertEquals(instanceJsonLdType, elementSchemaArtifact.instanceJsonLdType().get());
+    Assertions.assertEquals(jsonLdContext, elementSchemaArtifact.jsonLdContext());
+    Assertions.assertEquals(createdBy, elementSchemaArtifact.createdBy().get());
+    Assertions.assertEquals(modifiedBy, elementSchemaArtifact.modifiedBy().get());
+    Assertions.assertEquals(createdOn, elementSchemaArtifact.createdOn().get());
+    Assertions.assertEquals(lastUpdatedOn, elementSchemaArtifact.lastUpdatedOn().get());
+    Assertions.assertEquals(internalName, elementSchemaArtifact.internalName());
+    Assertions.assertEquals(internalDescription, elementSchemaArtifact.internalDescription());
+    Assertions.assertEquals(name, elementSchemaArtifact.name());
+    Assertions.assertEquals(description, elementSchemaArtifact.description());
+    Assertions.assertEquals(identifier, elementSchemaArtifact.identifier());
+    Assertions.assertEquals(version, elementSchemaArtifact.version());
+    Assertions.assertEquals(status, elementSchemaArtifact.status());
+    Assertions.assertEquals(previousVersion, elementSchemaArtifact.previousVersion());
+    Assertions.assertEquals(derivedFrom, elementSchemaArtifact.derivedFrom());
+    Assertions.assertEquals(propertyUri, elementSchemaArtifact.propertyUri());
+    Assertions.assertEquals(language, elementSchemaArtifact.language());
   }
 
   @Test public void testCreateElementSchemaArtifactWithChildren()
@@ -97,9 +97,9 @@ public class ElementSchemaArtifactTest
     assertEquals(elementSchemaArtifact.elementUi().propertyDescriptions().get(textFieldName2), textField2Description);
   }
 
-  @Test(expected = IllegalStateException.class) public void testMissingName()
+  @Test public void testMissingName()
   {
-    ElementSchemaArtifact elementSchemaArtifact = ElementSchemaArtifact.builder().build();
+    Assertions.assertThrows(IllegalStateException.class, () -> ElementSchemaArtifact.builder().build());
   }
 
 }

--- a/src/test/java/org/metadatacenter/artifacts/model/core/FieldInstanceArtifactTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/FieldInstanceArtifactTest.java
@@ -1,13 +1,13 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.XsdNumericDatatype;
 import org.metadatacenter.artifacts.model.core.fields.XsdTemporalDatatype;
 
 import java.net.URI;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FieldInstanceArtifactTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/FieldSchemaArtifactTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/FieldSchemaArtifactTest.java
@@ -1,7 +1,7 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.FieldInputType;
 import org.metadatacenter.artifacts.model.core.ui.FieldUi;
 
@@ -50,27 +50,27 @@ public class FieldSchemaArtifactTest
       Optional.of(modifiedBy), Optional.of(createdOn), Optional.of(lastUpdatedOn), preferredLabel, alternateLabels,
       language, FieldUi.builder().withInputType(FieldInputType.TEXTFIELD).build(), Optional.empty(), Optional.empty());
 
-    Assert.assertEquals(internalName, fieldSchemaArtifact.internalName());
-    Assert.assertEquals(internalDescription, fieldSchemaArtifact.internalDescription());
-    Assert.assertEquals(jsonLdTypes, fieldSchemaArtifact.jsonLdTypes());
-    Assert.assertEquals(jsonLdId, fieldSchemaArtifact.jsonLdId().get());
-    Assert.assertEquals(jsonLdContext, fieldSchemaArtifact.jsonLdContext());
-    Assert.assertEquals(createdBy, fieldSchemaArtifact.createdBy().get());
-    Assert.assertEquals(modifiedBy, fieldSchemaArtifact.modifiedBy().get());
-    Assert.assertEquals(createdOn, fieldSchemaArtifact.createdOn().get());
-    Assert.assertEquals(lastUpdatedOn, fieldSchemaArtifact.lastUpdatedOn().get());
-    Assert.assertEquals(name, fieldSchemaArtifact.name());
-    Assert.assertEquals(description, fieldSchemaArtifact.description());
-    Assert.assertEquals(identifier, fieldSchemaArtifact.identifier());
-    Assert.assertEquals(preferredLabel, fieldSchemaArtifact.preferredLabel());
-    Assert.assertEquals(alternateLabels, fieldSchemaArtifact.alternateLabels());
-    Assert.assertEquals(version, fieldSchemaArtifact.version());
-    Assert.assertEquals(status, fieldSchemaArtifact.status());
-    Assert.assertEquals(previousVersion, fieldSchemaArtifact.previousVersion());
-    Assert.assertEquals(derivedFrom, fieldSchemaArtifact.derivedFrom());
-    Assert.assertEquals(propertyUri, fieldSchemaArtifact.propertyUri());
-    Assert.assertEquals(language, fieldSchemaArtifact.language());
-    Assert.assertEquals(minItems, fieldSchemaArtifact.minItems());
+    Assertions.assertEquals(internalName, fieldSchemaArtifact.internalName());
+    Assertions.assertEquals(internalDescription, fieldSchemaArtifact.internalDescription());
+    Assertions.assertEquals(jsonLdTypes, fieldSchemaArtifact.jsonLdTypes());
+    Assertions.assertEquals(jsonLdId, fieldSchemaArtifact.jsonLdId().get());
+    Assertions.assertEquals(jsonLdContext, fieldSchemaArtifact.jsonLdContext());
+    Assertions.assertEquals(createdBy, fieldSchemaArtifact.createdBy().get());
+    Assertions.assertEquals(modifiedBy, fieldSchemaArtifact.modifiedBy().get());
+    Assertions.assertEquals(createdOn, fieldSchemaArtifact.createdOn().get());
+    Assertions.assertEquals(lastUpdatedOn, fieldSchemaArtifact.lastUpdatedOn().get());
+    Assertions.assertEquals(name, fieldSchemaArtifact.name());
+    Assertions.assertEquals(description, fieldSchemaArtifact.description());
+    Assertions.assertEquals(identifier, fieldSchemaArtifact.identifier());
+    Assertions.assertEquals(preferredLabel, fieldSchemaArtifact.preferredLabel());
+    Assertions.assertEquals(alternateLabels, fieldSchemaArtifact.alternateLabels());
+    Assertions.assertEquals(version, fieldSchemaArtifact.version());
+    Assertions.assertEquals(status, fieldSchemaArtifact.status());
+    Assertions.assertEquals(previousVersion, fieldSchemaArtifact.previousVersion());
+    Assertions.assertEquals(derivedFrom, fieldSchemaArtifact.derivedFrom());
+    Assertions.assertEquals(propertyUri, fieldSchemaArtifact.propertyUri());
+    Assertions.assertEquals(language, fieldSchemaArtifact.language());
+    Assertions.assertEquals(minItems, fieldSchemaArtifact.minItems());
   }
 
   @Test public void testCreateTextFieldWithBuilder()
@@ -101,24 +101,24 @@ public class FieldSchemaArtifactTest
       .withLastUpdatedOn(lastUpdatedOn).withPreviousVersion(previousVersion).withDerivedFrom(derivedFrom)
       .withPropertyUri(propertyUri).build();
 
-    Assert.assertEquals(jsonLdId, textField.jsonLdId().get());
-    Assert.assertEquals(createdBy, textField.createdBy().get());
-    Assert.assertEquals(modifiedBy, textField.modifiedBy().get());
-    Assert.assertEquals(createdOn, textField.createdOn().get());
-    Assert.assertEquals(lastUpdatedOn, textField.lastUpdatedOn().get());
-    Assert.assertEquals(name, textField.name());
-    Assert.assertEquals(description, textField.description());
-    Assert.assertEquals(identifier, textField.identifier().get());
-    Assert.assertEquals(preferredLabel, textField.preferredLabel().get());
-    Assert.assertEquals(alternateLabels, textField.alternateLabels());
-    Assert.assertEquals(version, textField.version().get());
-    Assert.assertEquals(status, textField.status().get());
-    Assert.assertEquals(previousVersion, textField.previousVersion().get());
-    Assert.assertEquals(derivedFrom, textField.derivedFrom().get());
-    Assert.assertEquals(propertyUri, textField.propertyUri().get());
-    Assert.assertEquals(requiredValue, textField.requiredValue());
-    Assert.assertEquals(minLength, textField.minLength().get());
-    Assert.assertEquals(maxLength, textField.maxLength().get());
+    Assertions.assertEquals(jsonLdId, textField.jsonLdId().get());
+    Assertions.assertEquals(createdBy, textField.createdBy().get());
+    Assertions.assertEquals(modifiedBy, textField.modifiedBy().get());
+    Assertions.assertEquals(createdOn, textField.createdOn().get());
+    Assertions.assertEquals(lastUpdatedOn, textField.lastUpdatedOn().get());
+    Assertions.assertEquals(name, textField.name());
+    Assertions.assertEquals(description, textField.description());
+    Assertions.assertEquals(identifier, textField.identifier().get());
+    Assertions.assertEquals(preferredLabel, textField.preferredLabel().get());
+    Assertions.assertEquals(alternateLabels, textField.alternateLabels());
+    Assertions.assertEquals(version, textField.version().get());
+    Assertions.assertEquals(status, textField.status().get());
+    Assertions.assertEquals(previousVersion, textField.previousVersion().get());
+    Assertions.assertEquals(derivedFrom, textField.derivedFrom().get());
+    Assertions.assertEquals(propertyUri, textField.propertyUri().get());
+    Assertions.assertEquals(requiredValue, textField.requiredValue());
+    Assertions.assertEquals(minLength, textField.minLength().get());
+    Assertions.assertEquals(maxLength, textField.maxLength().get());
   }
 
 }

--- a/src/test/java/org/metadatacenter/artifacts/model/core/InstanceArtifactVisitorTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/InstanceArtifactVisitorTest.java
@@ -3,8 +3,8 @@ package org.metadatacenter.artifacts.model.core;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.reader.JsonArtifactReader;
 import org.metadatacenter.artifacts.model.reader.JsonArtifactReaderTest;
 import org.metadatacenter.artifacts.model.visitors.TemplateReporter;
@@ -14,14 +14,14 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InstanceArtifactVisitorTest {
   private JsonArtifactReader artifactReader;
   private ObjectMapper mapper;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     artifactReader = new JsonArtifactReader();
     mapper = new ObjectMapper();

--- a/src/test/java/org/metadatacenter/artifacts/model/core/NumericValueConstraintsTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/NumericValueConstraintsTest.java
@@ -1,10 +1,10 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.constraints.NumericValueConstraints;
 import org.metadatacenter.artifacts.model.core.fields.XsdNumericDatatype;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NumericValueConstraintsTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/SchemaArtifactVisitorTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/SchemaArtifactVisitorTest.java
@@ -1,11 +1,11 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SchemaArtifactVisitorTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifactTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifactTest.java
@@ -1,12 +1,12 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TemplateInstanceArtifactTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/TemplateSchemaArtifactTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/TemplateSchemaArtifactTest.java
@@ -1,9 +1,10 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TemplateSchemaArtifactTest
 {
@@ -71,10 +72,9 @@ public class TemplateSchemaArtifactTest
     assertEquals(templateSchemaArtifact.templateUi().propertyDescriptions().get(textFieldName2), textField2Description);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testMissingName()
   {
-    TemplateSchemaArtifact templateSchemaArtifact = TemplateSchemaArtifact.builder()
-      .build();
+    Assertions.assertThrows(IllegalStateException.class, () -> TemplateSchemaArtifact.builder().build());
   }
 }

--- a/src/test/java/org/metadatacenter/artifacts/model/core/TextValueConstraintsTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/TextValueConstraintsTest.java
@@ -1,9 +1,9 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.constraints.TextValueConstraints;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TextValueConstraintsTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ValueTypeTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ValueTypeTest.java
@@ -1,9 +1,9 @@
 package org.metadatacenter.artifacts.model.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ValueType;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_TYPE_ONTOLOGY_CLASS;
 import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_TYPE_VALUE;
 
@@ -21,8 +21,8 @@ public class ValueTypeTest {
     assertEquals(ValueType.VALUE, ValueType.fromString(VALUE_CONSTRAINTS_TYPE_VALUE));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidValueTypeFromString() {
-    ValueType.fromString("InvalidValueType");
+    assertThrows(IllegalArgumentException.class, () -> ValueType.fromString("InvalidValueType"));
   }
 }

--- a/src/test/java/org/metadatacenter/artifacts/model/core/builders/FieldSchemaArtifactBuilderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/builders/FieldSchemaArtifactBuilderTest.java
@@ -1,7 +1,7 @@
 package org.metadatacenter.artifacts.model.core.builders;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.*;
 import org.metadatacenter.artifacts.model.core.fields.FieldInputType;
 import org.metadatacenter.artifacts.model.core.fields.InputTimeFormat;
@@ -32,13 +32,13 @@ public class FieldSchemaArtifactBuilderTest {
         withRegex(regex).withValueRecommendationEnabled(valueRecommendation).
         build();
 
-    Assert.assertEquals(FieldInputType.TEXTFIELD, textField.fieldUi().inputType());
-    Assert.assertEquals(name, textField.name());
-    Assert.assertEquals(description, textField.description());
-    Assert.assertEquals(minLength, textField.minLength().get());
-    Assert.assertEquals(maxLength, textField.maxLength().get());
-    Assert.assertEquals(regex, textField.regex().get());
-    Assert.assertEquals(valueRecommendation, textField.fieldUi().valueRecommendationEnabled());
+    Assertions.assertEquals(FieldInputType.TEXTFIELD, textField.fieldUi().inputType());
+    Assertions.assertEquals(name, textField.name());
+    Assertions.assertEquals(description, textField.description());
+    Assertions.assertEquals(minLength, textField.minLength().get());
+    Assertions.assertEquals(maxLength, textField.maxLength().get());
+    Assertions.assertEquals(regex, textField.regex().get());
+    Assertions.assertEquals(valueRecommendation, textField.fieldUi().valueRecommendationEnabled());
   }
 
   @Test
@@ -60,13 +60,13 @@ public class FieldSchemaArtifactBuilderTest {
 
     TextField clonedTextField = new TextField.TextFieldBuilder(initialTextField).build();
 
-    Assert.assertEquals(FieldInputType.TEXTFIELD, clonedTextField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedTextField.name());
-    Assert.assertEquals(description, clonedTextField.description());
-    Assert.assertEquals(minLength, clonedTextField.minLength().get());
-    Assert.assertEquals(maxLength, clonedTextField.maxLength().get());
-    Assert.assertEquals(regex, clonedTextField.regex().get());
-    Assert.assertEquals(valueRecommendation, clonedTextField.fieldUi().valueRecommendationEnabled());
+    Assertions.assertEquals(FieldInputType.TEXTFIELD, clonedTextField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedTextField.name());
+    Assertions.assertEquals(description, clonedTextField.description());
+    Assertions.assertEquals(minLength, clonedTextField.minLength().get());
+    Assertions.assertEquals(maxLength, clonedTextField.maxLength().get());
+    Assertions.assertEquals(regex, clonedTextField.regex().get());
+    Assertions.assertEquals(valueRecommendation, clonedTextField.fieldUi().valueRecommendationEnabled());
   }
 
   @Test
@@ -91,18 +91,18 @@ public class FieldSchemaArtifactBuilderTest {
         withDecimalPlaces(decimalPlaces).
         build();
 
-    Assert.assertEquals(FieldInputType.NUMERIC, numericField.fieldUi().inputType());
-    Assert.assertEquals(name, numericField.name());
-    Assert.assertEquals(description, numericField.description());
-    Assert.assertEquals(numericType, numericField.valueConstraints().get().asNumericValueConstraints().numberType());
-    Assert.assertEquals(defaultValue,
+    Assertions.assertEquals(FieldInputType.NUMERIC, numericField.fieldUi().inputType());
+    Assertions.assertEquals(name, numericField.name());
+    Assertions.assertEquals(description, numericField.description());
+    Assertions.assertEquals(numericType, numericField.valueConstraints().get().asNumericValueConstraints().numberType());
+    Assertions.assertEquals(defaultValue,
         numericField.valueConstraints().get().asNumericValueConstraints().defaultValue().get().value());
-    Assert.assertEquals(minValue, numericField.valueConstraints().get().asNumericValueConstraints().minValue().get());
-    Assert.assertEquals(maxValue, numericField.valueConstraints().get().asNumericValueConstraints().maxValue().get());
-    Assert.assertEquals(maxValue, numericField.valueConstraints().get().asNumericValueConstraints().maxValue().get());
-    Assert.assertEquals(unitOfMeasure,
+    Assertions.assertEquals(minValue, numericField.valueConstraints().get().asNumericValueConstraints().minValue().get());
+    Assertions.assertEquals(maxValue, numericField.valueConstraints().get().asNumericValueConstraints().maxValue().get());
+    Assertions.assertEquals(maxValue, numericField.valueConstraints().get().asNumericValueConstraints().maxValue().get());
+    Assertions.assertEquals(unitOfMeasure,
         numericField.valueConstraints().get().asNumericValueConstraints().unitOfMeasure().get());
-    Assert.assertEquals(decimalPlaces,
+    Assertions.assertEquals(decimalPlaces,
         numericField.valueConstraints().get().asNumericValueConstraints().decimalPlace().get());
   }
 
@@ -130,22 +130,22 @@ public class FieldSchemaArtifactBuilderTest {
 
     NumericField clonedNumericField = new NumericField.NumericFieldBuilder(initialNumericField).build();
 
-    Assert.assertEquals(FieldInputType.NUMERIC, clonedNumericField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedNumericField.name());
-    Assert.assertEquals(description, clonedNumericField.description());
-    Assert.assertEquals(numericType,
+    Assertions.assertEquals(FieldInputType.NUMERIC, clonedNumericField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedNumericField.name());
+    Assertions.assertEquals(description, clonedNumericField.description());
+    Assertions.assertEquals(numericType,
         clonedNumericField.valueConstraints().get().asNumericValueConstraints().numberType());
-    Assert.assertEquals(defaultValue,
+    Assertions.assertEquals(defaultValue,
         clonedNumericField.valueConstraints().get().asNumericValueConstraints().defaultValue().get().value());
-    Assert.assertEquals(minValue,
+    Assertions.assertEquals(minValue,
         clonedNumericField.valueConstraints().get().asNumericValueConstraints().minValue().get());
-    Assert.assertEquals(maxValue,
+    Assertions.assertEquals(maxValue,
         clonedNumericField.valueConstraints().get().asNumericValueConstraints().maxValue().get());
-    Assert.assertEquals(maxValue,
+    Assertions.assertEquals(maxValue,
         clonedNumericField.valueConstraints().get().asNumericValueConstraints().maxValue().get());
-    Assert.assertEquals(unitOfMeasure,
+    Assertions.assertEquals(unitOfMeasure,
         clonedNumericField.valueConstraints().get().asNumericValueConstraints().unitOfMeasure().get());
-    Assert.assertEquals(decimalPlaces,
+    Assertions.assertEquals(decimalPlaces,
         clonedNumericField.valueConstraints().get().asNumericValueConstraints().decimalPlace().get());
   }
 
@@ -167,13 +167,13 @@ public class FieldSchemaArtifactBuilderTest {
         withTimeZoneEnabled(timezoneEnabled).
         build();
 
-    Assert.assertEquals(FieldInputType.TEMPORAL, temporalField.fieldUi().inputType());
-    Assert.assertEquals(name, temporalField.name());
-    Assert.assertEquals(description, temporalField.description());
-    Assert.assertEquals(temporalGranularity, temporalField.fieldUi().asTemporalFieldUi().temporalGranularity());
-    Assert.assertEquals(inputTimeFormat, temporalField.fieldUi().asTemporalFieldUi().inputTimeFormat().get());
-    Assert.assertEquals(timezoneEnabled, temporalField.fieldUi().asTemporalFieldUi().timezoneEnabled().get());
-    Assert.assertEquals(temporalType,
+    Assertions.assertEquals(FieldInputType.TEMPORAL, temporalField.fieldUi().inputType());
+    Assertions.assertEquals(name, temporalField.name());
+    Assertions.assertEquals(description, temporalField.description());
+    Assertions.assertEquals(temporalGranularity, temporalField.fieldUi().asTemporalFieldUi().temporalGranularity());
+    Assertions.assertEquals(inputTimeFormat, temporalField.fieldUi().asTemporalFieldUi().inputTimeFormat().get());
+    Assertions.assertEquals(timezoneEnabled, temporalField.fieldUi().asTemporalFieldUi().timezoneEnabled().get());
+    Assertions.assertEquals(temporalType,
         temporalField.valueConstraints().get().asTemporalValueConstraints().temporalType());
   }
 
@@ -197,13 +197,13 @@ public class FieldSchemaArtifactBuilderTest {
 
     TemporalField clonedTemporalField = new TemporalField.TemporalFieldBuilder(initialTemporalField).build();
 
-    Assert.assertEquals(FieldInputType.TEMPORAL, clonedTemporalField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedTemporalField.name());
-    Assert.assertEquals(description, clonedTemporalField.description());
-    Assert.assertEquals(temporalGranularity, clonedTemporalField.fieldUi().asTemporalFieldUi().temporalGranularity());
-    Assert.assertEquals(inputTimeFormat, clonedTemporalField.fieldUi().asTemporalFieldUi().inputTimeFormat().get());
-    Assert.assertEquals(timezoneEnabled, clonedTemporalField.fieldUi().asTemporalFieldUi().timezoneEnabled().get());
-    Assert.assertEquals(temporalType,
+    Assertions.assertEquals(FieldInputType.TEMPORAL, clonedTemporalField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedTemporalField.name());
+    Assertions.assertEquals(description, clonedTemporalField.description());
+    Assertions.assertEquals(temporalGranularity, clonedTemporalField.fieldUi().asTemporalFieldUi().temporalGranularity());
+    Assertions.assertEquals(inputTimeFormat, clonedTemporalField.fieldUi().asTemporalFieldUi().inputTimeFormat().get());
+    Assertions.assertEquals(timezoneEnabled, clonedTemporalField.fieldUi().asTemporalFieldUi().timezoneEnabled().get());
+    Assertions.assertEquals(temporalType,
         clonedTemporalField.valueConstraints().get().asTemporalValueConstraints().temporalType());
   }
 
@@ -246,52 +246,52 @@ public class FieldSchemaArtifactBuilderTest {
             actionSourceUri, actionTo).
         build();
 
-    Assert.assertEquals(FieldInputType.TEXTFIELD, controlledTermField.fieldUi().inputType());
-    Assert.assertEquals(name, controlledTermField.name());
-    Assert.assertEquals(description, controlledTermField.description());
-    Assert.assertEquals(ontologyUri,
+    Assertions.assertEquals(FieldInputType.TEXTFIELD, controlledTermField.fieldUi().inputType());
+    Assertions.assertEquals(name, controlledTermField.name());
+    Assertions.assertEquals(description, controlledTermField.description());
+    Assertions.assertEquals(ontologyUri,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().ontologies().get(0).uri());
-    Assert.assertEquals(ontologyAcronym,
+    Assertions.assertEquals(ontologyAcronym,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().ontologies().get(0).acronym());
-    Assert.assertEquals(ontologyName,
+    Assertions.assertEquals(ontologyName,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().ontologies().get(0).name());
-    Assert.assertEquals(branchUri,
+    Assertions.assertEquals(branchUri,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).uri());
-    Assert.assertEquals(branchAcronym,
+    Assertions.assertEquals(branchAcronym,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).acronym());
-    Assert.assertEquals(branchName,
+    Assertions.assertEquals(branchName,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).name());
-    Assert.assertEquals(branchSource,
+    Assertions.assertEquals(branchSource,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).source());
-    Assert.assertEquals(branchMaxDepth,
+    Assertions.assertEquals(branchMaxDepth,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).maxDepth());
-    Assert.assertEquals(classUri,
+    Assertions.assertEquals(classUri,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).uri());
-    Assert.assertEquals(classSource,
+    Assertions.assertEquals(classSource,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).source());
-    Assert.assertEquals(classLabel,
+    Assertions.assertEquals(classLabel,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).label());
-    Assert.assertEquals(classPrefLabel,
+    Assertions.assertEquals(classPrefLabel,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).prefLabel());
-    Assert.assertEquals(classValueType,
+    Assertions.assertEquals(classValueType,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).type());
-    Assert.assertEquals(valueSetUri,
+    Assertions.assertEquals(valueSetUri,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().valueSets().get(0).uri());
-    Assert.assertEquals(valueSetCollection,
+    Assertions.assertEquals(valueSetCollection,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().valueSets().get(0).vsCollection());
-    Assert.assertEquals(valueSetName,
+    Assertions.assertEquals(valueSetName,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().valueSets().get(0).name());
-    Assert.assertEquals(valueSetNumTerms,
+    Assertions.assertEquals(valueSetNumTerms,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().valueSets().get(0).numTerms().get());
-    Assert.assertEquals(actionTermUri,
+    Assertions.assertEquals(actionTermUri,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).termUri());
-    Assert.assertEquals(actionSourceUri,
+    Assertions.assertEquals(actionSourceUri,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).sourceUri().get());
-    Assert.assertEquals(actionSource,
+    Assertions.assertEquals(actionSource,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).source());
-    Assert.assertEquals(actionValueType,
+    Assertions.assertEquals(actionValueType,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).type());
-    Assert.assertEquals(actionTo,
+    Assertions.assertEquals(actionTo,
         controlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).to().get());
   }
 
@@ -337,52 +337,52 @@ public class FieldSchemaArtifactBuilderTest {
     ControlledTermField clonedControlledTermField =
         new ControlledTermField.ControlledTermFieldBuilder(initialControlledTermField).build();
 
-    Assert.assertEquals(FieldInputType.TEXTFIELD, clonedControlledTermField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedControlledTermField.name());
-    Assert.assertEquals(description, clonedControlledTermField.description());
-    Assert.assertEquals(ontologyUri,
+    Assertions.assertEquals(FieldInputType.TEXTFIELD, clonedControlledTermField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedControlledTermField.name());
+    Assertions.assertEquals(description, clonedControlledTermField.description());
+    Assertions.assertEquals(ontologyUri,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().ontologies().get(0).uri());
-    Assert.assertEquals(ontologyAcronym,
+    Assertions.assertEquals(ontologyAcronym,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().ontologies().get(0).acronym());
-    Assert.assertEquals(ontologyName,
+    Assertions.assertEquals(ontologyName,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().ontologies().get(0).name());
-    Assert.assertEquals(branchUri,
+    Assertions.assertEquals(branchUri,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).uri());
-    Assert.assertEquals(branchAcronym,
+    Assertions.assertEquals(branchAcronym,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).acronym());
-    Assert.assertEquals(branchName,
+    Assertions.assertEquals(branchName,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).name());
-    Assert.assertEquals(branchSource,
+    Assertions.assertEquals(branchSource,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).source());
-    Assert.assertEquals(branchMaxDepth,
+    Assertions.assertEquals(branchMaxDepth,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().branches().get(0).maxDepth());
-    Assert.assertEquals(classUri,
+    Assertions.assertEquals(classUri,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).uri());
-    Assert.assertEquals(classSource,
+    Assertions.assertEquals(classSource,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).source());
-    Assert.assertEquals(classLabel,
+    Assertions.assertEquals(classLabel,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).label());
-    Assert.assertEquals(classPrefLabel,
+    Assertions.assertEquals(classPrefLabel,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).prefLabel());
-    Assert.assertEquals(classValueType,
+    Assertions.assertEquals(classValueType,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().classes().get(0).type());
-    Assert.assertEquals(valueSetUri,
+    Assertions.assertEquals(valueSetUri,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().valueSets().get(0).uri());
-    Assert.assertEquals(valueSetCollection,
+    Assertions.assertEquals(valueSetCollection,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().valueSets().get(0).vsCollection());
-    Assert.assertEquals(valueSetName,
+    Assertions.assertEquals(valueSetName,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().valueSets().get(0).name());
-    Assert.assertEquals(valueSetNumTerms,
+    Assertions.assertEquals(valueSetNumTerms,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().valueSets().get(0).numTerms().get());
-    Assert.assertEquals(actionTermUri,
+    Assertions.assertEquals(actionTermUri,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).termUri());
-    Assert.assertEquals(actionSourceUri,
+    Assertions.assertEquals(actionSourceUri,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).sourceUri().get());
-    Assert.assertEquals(actionSource,
+    Assertions.assertEquals(actionSource,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).source());
-    Assert.assertEquals(actionValueType,
+    Assertions.assertEquals(actionValueType,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).type());
-    Assert.assertEquals(actionTo,
+    Assertions.assertEquals(actionTo,
         clonedControlledTermField.valueConstraints().get().asControlledTermValueConstraints().actions().get(0).to().get());
   }
 
@@ -399,20 +399,20 @@ public class FieldSchemaArtifactBuilderTest {
         withOption("Choice 3", true).
         build();
 
-    Assert.assertEquals(FieldInputType.RADIO, radioField.fieldUi().inputType());
-    Assert.assertEquals(name, radioField.name());
-    Assert.assertEquals(description, radioField.description());
-    Assert.assertEquals("Choice 1",
+    Assertions.assertEquals(FieldInputType.RADIO, radioField.fieldUi().inputType());
+    Assertions.assertEquals(name, radioField.name());
+    Assertions.assertEquals(description, radioField.description());
+    Assertions.assertEquals("Choice 1",
         radioField.valueConstraints().get().asTextValueConstraints().literals().get(0).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         radioField.valueConstraints().get().asTextValueConstraints().literals().get(0).selectedByDefault());
-    Assert.assertEquals("Choice 2",
+    Assertions.assertEquals("Choice 2",
         radioField.valueConstraints().get().asTextValueConstraints().literals().get(1).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         radioField.valueConstraints().get().asTextValueConstraints().literals().get(1).selectedByDefault());
-    Assert.assertEquals("Choice 3",
+    Assertions.assertEquals("Choice 3",
         radioField.valueConstraints().get().asTextValueConstraints().literals().get(2).label());
-    Assert.assertEquals(true,
+    Assertions.assertEquals(true,
         radioField.valueConstraints().get().asTextValueConstraints().literals().get(2).selectedByDefault());
   }
 
@@ -431,20 +431,20 @@ public class FieldSchemaArtifactBuilderTest {
 
     RadioField clonedRadioField = new RadioField.RadioFieldBuilder(initialRadioField).build();
 
-    Assert.assertEquals(FieldInputType.RADIO, clonedRadioField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedRadioField.name());
-    Assert.assertEquals(description, clonedRadioField.description());
-    Assert.assertEquals("Choice 1",
+    Assertions.assertEquals(FieldInputType.RADIO, clonedRadioField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedRadioField.name());
+    Assertions.assertEquals(description, clonedRadioField.description());
+    Assertions.assertEquals("Choice 1",
         clonedRadioField.valueConstraints().get().asTextValueConstraints().literals().get(0).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         clonedRadioField.valueConstraints().get().asTextValueConstraints().literals().get(0).selectedByDefault());
-    Assert.assertEquals("Choice 2",
+    Assertions.assertEquals("Choice 2",
         clonedRadioField.valueConstraints().get().asTextValueConstraints().literals().get(1).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         clonedRadioField.valueConstraints().get().asTextValueConstraints().literals().get(1).selectedByDefault());
-    Assert.assertEquals("Choice 3",
+    Assertions.assertEquals("Choice 3",
         clonedRadioField.valueConstraints().get().asTextValueConstraints().literals().get(2).label());
-    Assert.assertEquals(true,
+    Assertions.assertEquals(true,
         clonedRadioField.valueConstraints().get().asTextValueConstraints().literals().get(2).selectedByDefault());
   }
 
@@ -462,22 +462,22 @@ public class FieldSchemaArtifactBuilderTest {
         withIsMultiple(true).
         build();
 
-    Assert.assertEquals(FieldInputType.LIST, listField.fieldUi().inputType());
-    Assert.assertEquals(name, listField.name());
-    Assert.assertEquals(description, listField.description());
-    Assert.assertEquals("Choice 1",
+    Assertions.assertEquals(FieldInputType.LIST, listField.fieldUi().inputType());
+    Assertions.assertEquals(name, listField.name());
+    Assertions.assertEquals(description, listField.description());
+    Assertions.assertEquals("Choice 1",
         listField.valueConstraints().get().asTextValueConstraints().literals().get(0).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         listField.valueConstraints().get().asTextValueConstraints().literals().get(0).selectedByDefault());
-    Assert.assertEquals("Choice 2",
+    Assertions.assertEquals("Choice 2",
         listField.valueConstraints().get().asTextValueConstraints().literals().get(1).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         listField.valueConstraints().get().asTextValueConstraints().literals().get(1).selectedByDefault());
-    Assert.assertEquals("Choice 3",
+    Assertions.assertEquals("Choice 3",
         listField.valueConstraints().get().asTextValueConstraints().literals().get(2).label());
-    Assert.assertEquals(true,
+    Assertions.assertEquals(true,
         listField.valueConstraints().get().asTextValueConstraints().literals().get(2).selectedByDefault());
-    Assert.assertEquals(true, listField.isMultiple());
+    Assertions.assertEquals(true, listField.isMultiple());
   }
 
   @Test
@@ -495,20 +495,20 @@ public class FieldSchemaArtifactBuilderTest {
 
     ListField clonedListField = new ListField.ListFieldBuilder(initialListField).build();
 
-    Assert.assertEquals(FieldInputType.LIST, clonedListField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedListField.name());
-    Assert.assertEquals(description, clonedListField.description());
-    Assert.assertEquals("Choice 1",
+    Assertions.assertEquals(FieldInputType.LIST, clonedListField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedListField.name());
+    Assertions.assertEquals(description, clonedListField.description());
+    Assertions.assertEquals("Choice 1",
         clonedListField.valueConstraints().get().asTextValueConstraints().literals().get(0).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         clonedListField.valueConstraints().get().asTextValueConstraints().literals().get(0).selectedByDefault());
-    Assert.assertEquals("Choice 2",
+    Assertions.assertEquals("Choice 2",
         clonedListField.valueConstraints().get().asTextValueConstraints().literals().get(1).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         clonedListField.valueConstraints().get().asTextValueConstraints().literals().get(1).selectedByDefault());
-    Assert.assertEquals("Choice 3",
+    Assertions.assertEquals("Choice 3",
         clonedListField.valueConstraints().get().asTextValueConstraints().literals().get(2).label());
-    Assert.assertEquals(true,
+    Assertions.assertEquals(true,
         clonedListField.valueConstraints().get().asTextValueConstraints().literals().get(2).selectedByDefault());
   }
 
@@ -525,20 +525,20 @@ public class FieldSchemaArtifactBuilderTest {
         withOption("Choice 3", true).
         build();
 
-    Assert.assertEquals(FieldInputType.CHECKBOX, checkboxField.fieldUi().inputType());
-    Assert.assertEquals(name, checkboxField.name());
-    Assert.assertEquals(description, checkboxField.description());
-    Assert.assertEquals("Choice 1",
+    Assertions.assertEquals(FieldInputType.CHECKBOX, checkboxField.fieldUi().inputType());
+    Assertions.assertEquals(name, checkboxField.name());
+    Assertions.assertEquals(description, checkboxField.description());
+    Assertions.assertEquals("Choice 1",
         checkboxField.valueConstraints().get().asTextValueConstraints().literals().get(0).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         checkboxField.valueConstraints().get().asTextValueConstraints().literals().get(0).selectedByDefault());
-    Assert.assertEquals("Choice 2",
+    Assertions.assertEquals("Choice 2",
         checkboxField.valueConstraints().get().asTextValueConstraints().literals().get(1).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         checkboxField.valueConstraints().get().asTextValueConstraints().literals().get(1).selectedByDefault());
-    Assert.assertEquals("Choice 3",
+    Assertions.assertEquals("Choice 3",
         checkboxField.valueConstraints().get().asTextValueConstraints().literals().get(2).label());
-    Assert.assertEquals(true,
+    Assertions.assertEquals(true,
         checkboxField.valueConstraints().get().asTextValueConstraints().literals().get(2).selectedByDefault());
   }
 
@@ -557,20 +557,20 @@ public class FieldSchemaArtifactBuilderTest {
 
     CheckboxField clonedCheckboxField = new CheckboxField.CheckboxFieldBuilder(initialCheckboxField).build();
 
-    Assert.assertEquals(FieldInputType.CHECKBOX, clonedCheckboxField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedCheckboxField.name());
-    Assert.assertEquals(description, clonedCheckboxField.description());
-    Assert.assertEquals("Choice 1",
+    Assertions.assertEquals(FieldInputType.CHECKBOX, clonedCheckboxField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedCheckboxField.name());
+    Assertions.assertEquals(description, clonedCheckboxField.description());
+    Assertions.assertEquals("Choice 1",
         clonedCheckboxField.valueConstraints().get().asTextValueConstraints().literals().get(0).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         clonedCheckboxField.valueConstraints().get().asTextValueConstraints().literals().get(0).selectedByDefault());
-    Assert.assertEquals("Choice 2",
+    Assertions.assertEquals("Choice 2",
         clonedCheckboxField.valueConstraints().get().asTextValueConstraints().literals().get(1).label());
-    Assert.assertEquals(false,
+    Assertions.assertEquals(false,
         clonedCheckboxField.valueConstraints().get().asTextValueConstraints().literals().get(1).selectedByDefault());
-    Assert.assertEquals("Choice 3",
+    Assertions.assertEquals("Choice 3",
         clonedCheckboxField.valueConstraints().get().asTextValueConstraints().literals().get(2).label());
-    Assert.assertEquals(true,
+    Assertions.assertEquals(true,
         clonedCheckboxField.valueConstraints().get().asTextValueConstraints().literals().get(2).selectedByDefault());
   }
 
@@ -588,11 +588,11 @@ public class FieldSchemaArtifactBuilderTest {
         withMaxLength(maxLength).
         build();
 
-    Assert.assertEquals(FieldInputType.PHONE_NUMBER, phoneNumberField.fieldUi().inputType());
-    Assert.assertEquals(name, phoneNumberField.name());
-    Assert.assertEquals(description, phoneNumberField.description());
-    Assert.assertEquals(minLength, phoneNumberField.minLength().get());
-    Assert.assertEquals(maxLength, phoneNumberField.maxLength().get());
+    Assertions.assertEquals(FieldInputType.PHONE_NUMBER, phoneNumberField.fieldUi().inputType());
+    Assertions.assertEquals(name, phoneNumberField.name());
+    Assertions.assertEquals(description, phoneNumberField.description());
+    Assertions.assertEquals(minLength, phoneNumberField.minLength().get());
+    Assertions.assertEquals(maxLength, phoneNumberField.maxLength().get());
   }
 
   @Test
@@ -612,11 +612,11 @@ public class FieldSchemaArtifactBuilderTest {
     PhoneNumberField clonedPhoneNumberField =
         new PhoneNumberField.PhoneNumberFieldBuilder(initialPhoneNumberField).build();
 
-    Assert.assertEquals(FieldInputType.PHONE_NUMBER, clonedPhoneNumberField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedPhoneNumberField.name());
-    Assert.assertEquals(description, clonedPhoneNumberField.description());
-    Assert.assertEquals(minLength, clonedPhoneNumberField.minLength().get());
-    Assert.assertEquals(maxLength, clonedPhoneNumberField.maxLength().get());
+    Assertions.assertEquals(FieldInputType.PHONE_NUMBER, clonedPhoneNumberField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedPhoneNumberField.name());
+    Assertions.assertEquals(description, clonedPhoneNumberField.description());
+    Assertions.assertEquals(minLength, clonedPhoneNumberField.minLength().get());
+    Assertions.assertEquals(maxLength, clonedPhoneNumberField.maxLength().get());
   }
 
   @Test
@@ -633,11 +633,11 @@ public class FieldSchemaArtifactBuilderTest {
         withMaxLength(maxLength).
         build();
 
-    Assert.assertEquals(FieldInputType.EMAIL, emailField.fieldUi().inputType());
-    Assert.assertEquals(name, emailField.name());
-    Assert.assertEquals(description, emailField.description());
-    Assert.assertEquals(minLength, emailField.minLength().get());
-    Assert.assertEquals(maxLength, emailField.maxLength().get());
+    Assertions.assertEquals(FieldInputType.EMAIL, emailField.fieldUi().inputType());
+    Assertions.assertEquals(name, emailField.name());
+    Assertions.assertEquals(description, emailField.description());
+    Assertions.assertEquals(minLength, emailField.minLength().get());
+    Assertions.assertEquals(maxLength, emailField.maxLength().get());
   }
 
   @Test
@@ -656,11 +656,11 @@ public class FieldSchemaArtifactBuilderTest {
 
     EmailField clonedEmailField = new EmailField.EmailFieldBuilder(initialEmailField).build();
 
-    Assert.assertEquals(FieldInputType.EMAIL, clonedEmailField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedEmailField.name());
-    Assert.assertEquals(description, clonedEmailField.description());
-    Assert.assertEquals(minLength, clonedEmailField.minLength().get());
-    Assert.assertEquals(maxLength, clonedEmailField.maxLength().get());
+    Assertions.assertEquals(FieldInputType.EMAIL, clonedEmailField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedEmailField.name());
+    Assertions.assertEquals(description, clonedEmailField.description());
+    Assertions.assertEquals(minLength, clonedEmailField.minLength().get());
+    Assertions.assertEquals(maxLength, clonedEmailField.maxLength().get());
   }
 
   @Test
@@ -675,10 +675,10 @@ public class FieldSchemaArtifactBuilderTest {
         withDefaultValue(defaultURI).
         build();
 
-    Assert.assertEquals(FieldInputType.LINK, linkField.fieldUi().inputType());
-    Assert.assertEquals(name, linkField.name());
-    Assert.assertEquals(description, linkField.description());
-    Assert.assertEquals(defaultURI,
+    Assertions.assertEquals(FieldInputType.LINK, linkField.fieldUi().inputType());
+    Assertions.assertEquals(name, linkField.name());
+    Assertions.assertEquals(description, linkField.description());
+    Assertions.assertEquals(defaultURI,
         linkField.valueConstraints().get().asLinkValueConstraints().defaultValue().get().termUri());
   }
 
@@ -696,10 +696,10 @@ public class FieldSchemaArtifactBuilderTest {
 
     LinkField clonedLinkField = new LinkField.LinkFieldBuilder(initialLinkField).build();
 
-    Assert.assertEquals(FieldInputType.LINK, clonedLinkField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedLinkField.name());
-    Assert.assertEquals(description, clonedLinkField.description());
-    Assert.assertEquals(defaultURI,
+    Assertions.assertEquals(FieldInputType.LINK, clonedLinkField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedLinkField.name());
+    Assertions.assertEquals(description, clonedLinkField.description());
+    Assertions.assertEquals(defaultURI,
         clonedLinkField.valueConstraints().get().asLinkValueConstraints().defaultValue().get().termUri());
   }
 
@@ -718,10 +718,10 @@ public class FieldSchemaArtifactBuilderTest {
 
     RorField clonedRorField = new RorField.RorFieldBuilder(initialRorField).build();
 
-    Assert.assertEquals(FieldInputType.ROR, clonedRorField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedRorField.name());
-    Assert.assertEquals(description, clonedRorField.description());
-    Assert.assertEquals(defaultURI,
+    Assertions.assertEquals(FieldInputType.ROR, clonedRorField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedRorField.name());
+    Assertions.assertEquals(description, clonedRorField.description());
+    Assertions.assertEquals(defaultURI,
         clonedRorField.valueConstraints().get().asLinkValueConstraints().defaultValue().get().termUri());
   }
 
@@ -739,10 +739,10 @@ public class FieldSchemaArtifactBuilderTest {
 
     OrcidField clonedOrcidField = new OrcidField.OrcidFieldBuilder(initialOrcidField).build();
 
-    Assert.assertEquals(FieldInputType.ORCID, clonedOrcidField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedOrcidField.name());
-    Assert.assertEquals(description, clonedOrcidField.description());
-    Assert.assertEquals(defaultURI,
+    Assertions.assertEquals(FieldInputType.ORCID, clonedOrcidField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedOrcidField.name());
+    Assertions.assertEquals(description, clonedOrcidField.description());
+    Assertions.assertEquals(defaultURI,
         clonedOrcidField.valueConstraints().get().asLinkValueConstraints().defaultValue().get().termUri());
   }
 
@@ -760,10 +760,10 @@ public class FieldSchemaArtifactBuilderTest {
 
     PfasField clonedPfasField = new PfasField.PfasFieldBuilder(initialPfasField).build();
 
-    Assert.assertEquals(FieldInputType.PFAS, clonedPfasField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedPfasField.name());
-    Assert.assertEquals(description, clonedPfasField.description());
-    Assert.assertEquals(defaultURI,
+    Assertions.assertEquals(FieldInputType.PFAS, clonedPfasField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedPfasField.name());
+    Assertions.assertEquals(description, clonedPfasField.description());
+    Assertions.assertEquals(defaultURI,
         clonedPfasField.valueConstraints().get().asLinkValueConstraints().defaultValue().get().termUri());
   }
 
@@ -781,11 +781,11 @@ public class FieldSchemaArtifactBuilderTest {
         withMaxLength(maxLength).
         build();
 
-    Assert.assertEquals(FieldInputType.TEXTAREA, textAreaField.fieldUi().inputType());
-    Assert.assertEquals(name, textAreaField.name());
-    Assert.assertEquals(description, textAreaField.description());
-    Assert.assertEquals(minLength, textAreaField.minLength().get());
-    Assert.assertEquals(maxLength, textAreaField.maxLength().get());
+    Assertions.assertEquals(FieldInputType.TEXTAREA, textAreaField.fieldUi().inputType());
+    Assertions.assertEquals(name, textAreaField.name());
+    Assertions.assertEquals(description, textAreaField.description());
+    Assertions.assertEquals(minLength, textAreaField.minLength().get());
+    Assertions.assertEquals(maxLength, textAreaField.maxLength().get());
   }
 
   @Test
@@ -800,11 +800,11 @@ public class FieldSchemaArtifactBuilderTest {
 
     TextAreaField clonedTextAreaField = new TextAreaField.TextAreaFieldBuilder(initialTextAreaField).build();
 
-    Assert.assertEquals(FieldInputType.TEXTAREA, clonedTextAreaField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedTextAreaField.name());
-    Assert.assertEquals(description, clonedTextAreaField.description());
-    Assert.assertEquals(minLength, clonedTextAreaField.minLength().get());
-    Assert.assertEquals(maxLength, clonedTextAreaField.maxLength().get());
+    Assertions.assertEquals(FieldInputType.TEXTAREA, clonedTextAreaField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedTextAreaField.name());
+    Assertions.assertEquals(description, clonedTextAreaField.description());
+    Assertions.assertEquals(minLength, clonedTextAreaField.minLength().get());
+    Assertions.assertEquals(maxLength, clonedTextAreaField.maxLength().get());
   }
 
   @Test
@@ -817,9 +817,9 @@ public class FieldSchemaArtifactBuilderTest {
         withDescription(description).
         build();
 
-    Assert.assertEquals(FieldInputType.ATTRIBUTE_VALUE, attributeValueField.fieldUi().inputType());
-    Assert.assertEquals(name, attributeValueField.name());
-    Assert.assertEquals(description, attributeValueField.description());
+    Assertions.assertEquals(FieldInputType.ATTRIBUTE_VALUE, attributeValueField.fieldUi().inputType());
+    Assertions.assertEquals(name, attributeValueField.name());
+    Assertions.assertEquals(description, attributeValueField.description());
   }
 
   @Test
@@ -833,9 +833,9 @@ public class FieldSchemaArtifactBuilderTest {
     AttributeValueField clonedAttributeValueField = new AttributeValueField.AttributeValueFieldBuilder(
         initialAttributeValueField).build();
 
-    Assert.assertEquals(FieldInputType.ATTRIBUTE_VALUE, clonedAttributeValueField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedAttributeValueField.name());
-    Assert.assertEquals(description, clonedAttributeValueField.description());
+    Assertions.assertEquals(FieldInputType.ATTRIBUTE_VALUE, clonedAttributeValueField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedAttributeValueField.name());
+    Assertions.assertEquals(description, clonedAttributeValueField.description());
   }
 
   @Test
@@ -850,10 +850,10 @@ public class FieldSchemaArtifactBuilderTest {
         withContent(content).
         build();
 
-    Assert.assertEquals(FieldInputType.PAGE_BREAK, pageBreakField.fieldUi().inputType());
-    Assert.assertEquals(name, pageBreakField.name());
-    Assert.assertEquals(description, pageBreakField.description());
-    Assert.assertEquals(content, pageBreakField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.PAGE_BREAK, pageBreakField.fieldUi().inputType());
+    Assertions.assertEquals(name, pageBreakField.name());
+    Assertions.assertEquals(description, pageBreakField.description());
+    Assertions.assertEquals(content, pageBreakField.fieldUi().asStaticFieldUi()._content().get());
   }
 
   @Test
@@ -871,11 +871,11 @@ public class FieldSchemaArtifactBuilderTest {
 
     PageBreakField clonedPageBreakField = new PageBreakField.PageBreakFieldBuilder(initialPageBreakField).build();
 
-    Assert.assertEquals(FieldInputType.PAGE_BREAK, clonedPageBreakField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedPageBreakField.name());
-    Assert.assertEquals(description, clonedPageBreakField.description());
-    Assert.assertEquals(preferredLabel, clonedPageBreakField.preferredLabel().get());
-    Assert.assertEquals(content, clonedPageBreakField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.PAGE_BREAK, clonedPageBreakField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedPageBreakField.name());
+    Assertions.assertEquals(description, clonedPageBreakField.description());
+    Assertions.assertEquals(preferredLabel, clonedPageBreakField.preferredLabel().get());
+    Assertions.assertEquals(content, clonedPageBreakField.fieldUi().asStaticFieldUi()._content().get());
   }
 
   @Test
@@ -892,11 +892,11 @@ public class FieldSchemaArtifactBuilderTest {
         withContent(content).
         build();
 
-    Assert.assertEquals(FieldInputType.SECTION_BREAK, sectionBreakField.fieldUi().inputType());
-    Assert.assertEquals(name, sectionBreakField.name());
-    Assert.assertEquals(description, sectionBreakField.description());
-    Assert.assertEquals(preferredLabel, sectionBreakField.preferredLabel().get());
-    Assert.assertEquals(content, sectionBreakField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.SECTION_BREAK, sectionBreakField.fieldUi().inputType());
+    Assertions.assertEquals(name, sectionBreakField.name());
+    Assertions.assertEquals(description, sectionBreakField.description());
+    Assertions.assertEquals(preferredLabel, sectionBreakField.preferredLabel().get());
+    Assertions.assertEquals(content, sectionBreakField.fieldUi().asStaticFieldUi()._content().get());
   }
 
   @Test
@@ -916,11 +916,11 @@ public class FieldSchemaArtifactBuilderTest {
     SectionBreakField clonedSectionBreakField = new SectionBreakField.SectionBreakFieldBuilder(
         initialSectionBreakField).build();
 
-    Assert.assertEquals(FieldInputType.SECTION_BREAK, clonedSectionBreakField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedSectionBreakField.name());
-    Assert.assertEquals(description, clonedSectionBreakField.description());
-    Assert.assertEquals(preferredLabel, clonedSectionBreakField.preferredLabel().get());
-    Assert.assertEquals(content, clonedSectionBreakField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.SECTION_BREAK, clonedSectionBreakField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedSectionBreakField.name());
+    Assertions.assertEquals(description, clonedSectionBreakField.description());
+    Assertions.assertEquals(preferredLabel, clonedSectionBreakField.preferredLabel().get());
+    Assertions.assertEquals(content, clonedSectionBreakField.fieldUi().asStaticFieldUi()._content().get());
   }
 
   @Test
@@ -937,11 +937,11 @@ public class FieldSchemaArtifactBuilderTest {
         withContent(content).
         build();
 
-    Assert.assertEquals(FieldInputType.IMAGE, imageField.fieldUi().inputType());
-    Assert.assertEquals(name, imageField.name());
-    Assert.assertEquals(description, imageField.description());
-    Assert.assertEquals(preferredLabel, imageField.preferredLabel().get());
-    Assert.assertEquals(content, imageField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.IMAGE, imageField.fieldUi().inputType());
+    Assertions.assertEquals(name, imageField.name());
+    Assertions.assertEquals(description, imageField.description());
+    Assertions.assertEquals(preferredLabel, imageField.preferredLabel().get());
+    Assertions.assertEquals(content, imageField.fieldUi().asStaticFieldUi()._content().get());
   }
 
   @Test
@@ -960,11 +960,11 @@ public class FieldSchemaArtifactBuilderTest {
 
     ImageField clonedImageField = new ImageField.ImageFieldBuilder(initialImageField).build();
 
-    Assert.assertEquals(FieldInputType.IMAGE, clonedImageField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedImageField.name());
-    Assert.assertEquals(description, clonedImageField.description());
-    Assert.assertEquals(preferredLabel, clonedImageField.preferredLabel().get());
-    Assert.assertEquals(content, clonedImageField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.IMAGE, clonedImageField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedImageField.name());
+    Assertions.assertEquals(description, clonedImageField.description());
+    Assertions.assertEquals(preferredLabel, clonedImageField.preferredLabel().get());
+    Assertions.assertEquals(content, clonedImageField.fieldUi().asStaticFieldUi()._content().get());
   }
 
   @Test
@@ -981,11 +981,11 @@ public class FieldSchemaArtifactBuilderTest {
         withContent(content).
         build();
 
-    Assert.assertEquals(FieldInputType.YOUTUBE, youTubeField.fieldUi().inputType());
-    Assert.assertEquals(name, youTubeField.name());
-    Assert.assertEquals(description, youTubeField.description());
-    Assert.assertEquals(preferredLabel, youTubeField.preferredLabel().get());
-    Assert.assertEquals(content, youTubeField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.YOUTUBE, youTubeField.fieldUi().inputType());
+    Assertions.assertEquals(name, youTubeField.name());
+    Assertions.assertEquals(description, youTubeField.description());
+    Assertions.assertEquals(preferredLabel, youTubeField.preferredLabel().get());
+    Assertions.assertEquals(content, youTubeField.fieldUi().asStaticFieldUi()._content().get());
   }
 
   @Test
@@ -1004,11 +1004,11 @@ public class FieldSchemaArtifactBuilderTest {
 
     YouTubeField clonedYouTubeField = new YouTubeField.YouTubeFieldBuilder(initialYouTubeField).build();
 
-    Assert.assertEquals(FieldInputType.YOUTUBE, clonedYouTubeField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedYouTubeField.name());
-    Assert.assertEquals(description, clonedYouTubeField.description());
-    Assert.assertEquals(preferredLabel, clonedYouTubeField.preferredLabel().get());
-    Assert.assertEquals(content, clonedYouTubeField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.YOUTUBE, clonedYouTubeField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedYouTubeField.name());
+    Assertions.assertEquals(description, clonedYouTubeField.description());
+    Assertions.assertEquals(preferredLabel, clonedYouTubeField.preferredLabel().get());
+    Assertions.assertEquals(content, clonedYouTubeField.fieldUi().asStaticFieldUi()._content().get());
   }
 
   @Test
@@ -1025,11 +1025,11 @@ public class FieldSchemaArtifactBuilderTest {
         withContent(content).
         build();
 
-    Assert.assertEquals(FieldInputType.RICHTEXT, richTextField.fieldUi().inputType());
-    Assert.assertEquals(name, richTextField.name());
-    Assert.assertEquals(description, richTextField.description());
-    Assert.assertEquals(preferredLabel, richTextField.preferredLabel().get());
-    Assert.assertEquals(content, richTextField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.RICHTEXT, richTextField.fieldUi().inputType());
+    Assertions.assertEquals(name, richTextField.name());
+    Assertions.assertEquals(description, richTextField.description());
+    Assertions.assertEquals(preferredLabel, richTextField.preferredLabel().get());
+    Assertions.assertEquals(content, richTextField.fieldUi().asStaticFieldUi()._content().get());
   }
 
   @Test
@@ -1048,11 +1048,11 @@ public class FieldSchemaArtifactBuilderTest {
 
     RichTextField clonedRichTextField = new RichTextField.RichTextFieldBuilder(initialRichTextField).build();
 
-    Assert.assertEquals(FieldInputType.RICHTEXT, clonedRichTextField.fieldUi().inputType());
-    Assert.assertEquals(name, clonedRichTextField.name());
-    Assert.assertEquals(description, clonedRichTextField.description());
-    Assert.assertEquals(preferredLabel, clonedRichTextField.preferredLabel().get());
-    Assert.assertEquals(content, clonedRichTextField.fieldUi().asStaticFieldUi()._content().get());
+    Assertions.assertEquals(FieldInputType.RICHTEXT, clonedRichTextField.fieldUi().inputType());
+    Assertions.assertEquals(name, clonedRichTextField.name());
+    Assertions.assertEquals(description, clonedRichTextField.description());
+    Assertions.assertEquals(preferredLabel, clonedRichTextField.preferredLabel().get());
+    Assertions.assertEquals(content, clonedRichTextField.fieldUi().asStaticFieldUi()._content().get());
   }
 
 }

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ui/ElementUiTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ui/ElementUiTest.java
@@ -1,9 +1,9 @@
 package org.metadatacenter.artifacts.model.core.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class ElementUiTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ui/FieldUiTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ui/FieldUiTest.java
@@ -1,11 +1,11 @@
 package org.metadatacenter.artifacts.model.core.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.FieldInputType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FieldUiTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ui/NumericFieldUiTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ui/NumericFieldUiTest.java
@@ -1,10 +1,10 @@
 package org.metadatacenter.artifacts.model.core.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.FieldInputType;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NumericFieldUiTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ui/StaticFieldUiTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ui/StaticFieldUiTest.java
@@ -1,10 +1,10 @@
 package org.metadatacenter.artifacts.model.core.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.FieldInputType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StaticFieldUiTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ui/TemplateUiTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ui/TemplateUiTest.java
@@ -1,11 +1,11 @@
 package org.metadatacenter.artifacts.model.core.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TemplateUiTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ui/TemporalFieldUiTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ui/TemporalFieldUiTest.java
@@ -1,11 +1,11 @@
 package org.metadatacenter.artifacts.model.core.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.FieldInputType;
 import org.metadatacenter.artifacts.model.core.fields.InputTimeFormat;
 import org.metadatacenter.artifacts.model.core.fields.TemporalGranularity;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TemporalFieldUiTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/JsonArtifactReaderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/JsonArtifactReaderTest.java
@@ -3,8 +3,8 @@ package org.metadatacenter.artifacts.model.reader;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.ElementSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.FieldSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.TemplateInstanceArtifact;
@@ -16,9 +16,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.metadatacenter.model.ModelNodeNames.ELEMENT_SCHEMA_ARTIFACT_TYPE_IRI;
 import static org.metadatacenter.model.ModelNodeNames.FIELD_INPUT_TYPE_TEXTFIELD;
 import static org.metadatacenter.model.ModelNodeNames.FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
@@ -46,7 +46,7 @@ public class JsonArtifactReaderTest
   private JsonArtifactReader artifactReader;
   private ObjectMapper mapper;
 
-  @Before public void setup()
+  @BeforeEach public void setup()
   {
     artifactReader = new JsonArtifactReader();
     mapper = new ObjectMapper();

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReaderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReaderTest.java
@@ -2,9 +2,9 @@ package org.metadatacenter.artifacts.model.reader;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.ElementSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.FieldSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.Status;
@@ -19,7 +19,7 @@ import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ALT_LABEL;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.CREATED_BY;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.CREATED_ON;
@@ -53,7 +53,7 @@ public class YamlArtifactReaderTest
   private YamlArtifactReader artifactReader;
   private ObjectMapper objectMapper;
 
-  @Before public void setup()
+  @BeforeEach public void setup()
   {
     artifactReader = new YamlArtifactReader();
     objectMapper = new ObjectMapper(new YAMLFactory());
@@ -171,7 +171,7 @@ public class YamlArtifactReaderTest
   }
 
   // TODO Need to activate this
-  @Ignore @Test public void readFieldSchemaArtifactTest()
+  @Disabled @Test public void readFieldSchemaArtifactTest()
   {
     String fieldKey = "study_name";
     String fieldName = "Study Name";

--- a/src/test/java/org/metadatacenter/artifacts/model/renderer/JsonArtifactRendererTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/renderer/JsonArtifactRendererTest.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.ControlledTermField;
 import org.metadatacenter.artifacts.model.core.ElementInstanceArtifact;
 import org.metadatacenter.artifacts.model.core.FieldInstanceArtifact;
@@ -35,9 +35,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.metadatacenter.model.ModelNodeNames.FIELD_SCHEMA_ARTIFACT_TYPE_IRI;
 import static org.metadatacenter.model.ModelNodeNames.JSON_LD_ID;
 import static org.metadatacenter.model.ModelNodeNames.JSON_LD_TYPE;
@@ -63,7 +63,7 @@ public class JsonArtifactRendererTest
   private ObjectMapper mapper;
   private ModelValidator cedarModelValidator;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     artifactReader = new JsonArtifactReader();
     jsonArtifactRenderer = new JsonArtifactRenderer();

--- a/src/test/java/org/metadatacenter/artifacts/model/renderer/YamlArtifactRendererTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/renderer/YamlArtifactRendererTest.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.*;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ValueConstraintsActionType;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ValueType;
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.*;
 
 public class YamlArtifactRendererTest {
@@ -30,7 +30,7 @@ public class YamlArtifactRendererTest {
   private YAMLFactory yamlFactory;
   private ObjectMapper mapper;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     yamlFactory = new YAMLFactory().
         disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER).

--- a/src/test/java/org/metadatacenter/artifacts/model/visitors/TemplateSchemaInstanceReporterTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/visitors/TemplateSchemaInstanceReporterTest.java
@@ -1,6 +1,6 @@
 package org.metadatacenter.artifacts.model.visitors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.ElementSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.NumericField;
 import org.metadatacenter.artifacts.model.core.TemplateSchemaArtifact;
@@ -10,8 +10,8 @@ import org.metadatacenter.artifacts.model.core.fields.TemporalGranularity;
 import org.metadatacenter.artifacts.model.core.fields.XsdNumericDatatype;
 import org.metadatacenter.artifacts.model.core.fields.XsdTemporalDatatype;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TemplateSchemaInstanceReporterTest
 {


### PR DESCRIPTION
Re-open of [#32](https://github.com/metadatacenter/cedar-artifact-library/pull/32). That PR was stacked on \`claude/ci-and-hygiene\` (the base for PR #31); when #31 merged and its branch was auto-deleted, the "Merge" on #32 wrote its merge commit to the now-deleted base instead of \`develop\`. Same content, same head commit (\`8324bc3\`), now targeting \`develop\` directly.

## Summary

- Replace \`junit:junit\` with \`org.junit.jupiter:junit-jupiter\` 5.11.3 in \`pom.xml\`.
- Rewrite test-source imports across all 25 test files:
  - \`org.junit.Test\` → \`org.junit.jupiter.api.Test\`
  - \`org.junit.Before\` → \`org.junit.jupiter.api.BeforeEach\`
  - \`org.junit.Ignore\` → \`org.junit.jupiter.api.Disabled\`
  - \`org.junit.Assert\` → \`org.junit.jupiter.api.Assertions\`
- Replace \`@Before\` / \`@Ignore\` annotations accordingly.
- Rewrite three \`@Test(expected = Foo.class)\` sites to \`assertThrows\` lambdas (\`TemplateSchemaArtifactTest\`, \`ElementSchemaArtifactTest\`, \`ValueTypeTest\`).

Diff: 26 files, +413 / −412 — almost entirely mechanical import rewrites.

## Why now

Sets up for collapsing the 30+ near-identical per-field-type tests in \`FieldSchemaArtifactBuilderTest\` into a handful of \`@ParameterizedTest\` methods, only practical under JUnit 5.

## Test plan

- [x] \`mvn clean test\` → 269 tests, 0 failures, 3 pre-existing skips
- [x] \`mvn spotless:check\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)