### PR TITLE
Fix YOUTUBE arm: pass preferredLabel (not language) to YouTubeField.create

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/core/FieldSchemaArtifact.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/FieldSchemaArtifact.java
@@ -173,7 +173,7 @@ public sealed interface FieldSchemaArtifact extends SchemaArtifact, ChildSchemaA
         status, previousVersion, derivedFrom, createdBy, modifiedBy, createdOn, lastUpdatedOn, language, preferredLabel,
         fieldUi, annotations, internalName, internalDescription);
       case YOUTUBE -> YouTubeField.create(jsonLdContext, jsonLdTypes, jsonLdId, name, description, identifier, version,
-        status, previousVersion, derivedFrom, createdBy, modifiedBy, createdOn, lastUpdatedOn, language, fieldUi,
+        status, previousVersion, derivedFrom, createdBy, modifiedBy, createdOn, lastUpdatedOn, preferredLabel, fieldUi,
         annotations, internalName, internalDescription);
     };
   }

--- a/src/test/java/org/metadatacenter/artifacts/model/core/FieldSchemaArtifactTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/FieldSchemaArtifactTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.fields.FieldInputType;
 import org.metadatacenter.artifacts.model.core.ui.FieldUi;
+import org.metadatacenter.artifacts.model.core.ui.StaticFieldUi;
 
 import java.net.URI;
 import java.time.OffsetDateTime;
@@ -13,6 +14,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.metadatacenter.model.ModelNodeNames.FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
+import static org.metadatacenter.model.ModelNodeNames.STATIC_FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
+import static org.metadatacenter.model.ModelNodeNames.STATIC_FIELD_SCHEMA_ARTIFACT_TYPE_IRI;
 
 public class FieldSchemaArtifactTest
 {
@@ -71,6 +74,28 @@ public class FieldSchemaArtifactTest
     Assertions.assertEquals(propertyUri, fieldSchemaArtifact.propertyUri());
     Assertions.assertEquals(language, fieldSchemaArtifact.language());
     Assertions.assertEquals(minItems, fieldSchemaArtifact.minItems());
+  }
+
+  @Test public void testCreateYouTubeFieldPreservesPreferredLabel()
+  {
+    // Regression test for a positional-argument bug in FieldSchemaArtifact.create's YOUTUBE arm:
+    // the outer `language` variable was being passed into YouTubeField.create's preferredLabel slot,
+    // silently discarding the outer preferredLabel for YouTube fields.
+    LinkedHashMap<String, URI> jsonLdContext = new LinkedHashMap<>(STATIC_FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS);
+    List<URI> jsonLdTypes = Collections.singletonList(URI.create(STATIC_FIELD_SCHEMA_ARTIFACT_TYPE_IRI));
+
+    Optional<String> preferredLabel = Optional.of("Pref");
+    Optional<String> language = Optional.of("en");
+
+    FieldSchemaArtifact fieldSchemaArtifact = FieldSchemaArtifact.create("yt internal name", "yt internal description",
+      jsonLdContext, jsonLdTypes, Optional.empty(), "yt name", "yt description", Optional.empty(), Optional.empty(),
+      Optional.empty(), Optional.empty(), Optional.empty(), false, Optional.empty(), Optional.empty(), Optional.empty(),
+      Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), preferredLabel, Collections.emptyList(),
+      language, StaticFieldUi.youTubeFieldUiBuilder().build(), Optional.empty(), Optional.empty());
+
+    Assertions.assertInstanceOf(YouTubeField.class, fieldSchemaArtifact);
+    Assertions.assertEquals(preferredLabel, fieldSchemaArtifact.preferredLabel(),
+      "outer preferredLabel must be preserved on YouTube field");
   }
 
   @Test public void testCreateTextFieldWithBuilder()


### PR DESCRIPTION
Spotted while doing the [#36](https://github.com/metadatacenter/cedar-artifact-library/pull/36) refactor — preserved verbatim there to keep the refactor zero-behavior-change, fixed here.

## The bug

In \`FieldSchemaArtifact.create()\`, the YOUTUBE dispatch arm was passing the outer \`language\` variable into the \`preferredLabel\` parameter slot of \`YouTubeField.create\`. Positions for the relevant slice of \`YouTubeField.create\`:

\`\`\`text
..., Optional<OffsetDateTime> lastUpdatedOn, Optional<String> preferredLabel, FieldUi fieldUi, ...
                                              ^^^^^^^^^^^^^^^
                                              outer `language` was passed here
\`\`\`

So any YouTube field read from JSON or YAML had its language code (e.g. \`"en"\`) masquerading as its \`preferredLabel\`, and the outer \`preferredLabel\` was silently dropped.

Callers of \`FieldSchemaArtifact.create()\` that hit this path: \`JsonArtifactReader.readFieldSchemaArtifact\` and \`YamlArtifactReader.readFieldSchemaArtifact\`. So any persisted YouTube field round-tripping through the readers carries this corruption.

The other 22 arms all align correctly with their respective \`Foo.create()\` signatures — I checked each one.

## Fix

Single character: \`language\` → \`preferredLabel\` in the YOUTUBE arm of the \`switch\` expression in [FieldSchemaArtifact.java](src/main/java/org/metadatacenter/artifacts/model/core/FieldSchemaArtifact.java).

## Regression test

Added \`FieldSchemaArtifactTest#testCreateYouTubeFieldPreservesPreferredLabel\` which constructs a YouTube field via \`FieldSchemaArtifact.create()\` with distinct \`preferredLabel\` and \`language\` values, and asserts the outer \`preferredLabel\` survives the round trip.

I verified locally that the test fails against the buggy code with:
\`\`\`
expected: <Optional[Pref]> but was: <Optional[en]>
\`\`\`
and passes against the fix.

## Test plan

- [x] \`mvn clean test\` → 270 tests, 0 failures, 3 pre-existing skips (one new test added)
- [x] \`mvn spotless:check\` → clean
- [x] Regression test fails without the source fix; passes with it

## Possible follow-up

Any persisted YouTube fields in production CEDAR instances may currently have their \`preferredLabel\` field populated with a language code. A data-fix migration on the metadata repository may be in order. Out of scope for this PR; flagging in case it's worth a Linear/Jira ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)