### PR TITLE
Split JsonArtifactRenderer into a main class plus three package-private helpers

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonArtifactRenderer.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonArtifactRenderer.java
@@ -22,11 +22,9 @@ import org.metadatacenter.artifacts.model.core.SchemaArtifact;
 import org.metadatacenter.artifacts.model.core.TemplateInstanceArtifact;
 import org.metadatacenter.artifacts.model.core.TemplateSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.Version;
-import org.metadatacenter.artifacts.model.core.fields.XsdDatatype;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ValueConstraints;
 
 import java.net.URI;
-import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -36,27 +34,14 @@ import java.util.UUID;
 
 import static org.metadatacenter.model.ModelNodeNames.ANNOTATIONS;
 import static org.metadatacenter.model.ModelNodeNames.BIBO_STATUS;
-import static org.metadatacenter.model.ModelNodeNames.FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
-import static org.metadatacenter.model.ModelNodeNames.INSTANCE_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
 import static org.metadatacenter.model.ModelNodeNames.JSON_LD_CONTEXT;
 import static org.metadatacenter.model.ModelNodeNames.JSON_LD_ID;
 import static org.metadatacenter.model.ModelNodeNames.JSON_LD_LANGUAGE;
 import static org.metadatacenter.model.ModelNodeNames.JSON_LD_TYPE;
 import static org.metadatacenter.model.ModelNodeNames.JSON_LD_VALUE;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_ADDITIONAL_PROPERTIES;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_ARRAY;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_DESCRIPTION;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_ENUM;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_FORMAT;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_FORMAT_DATE_TIME;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_FORMAT_URI;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_ITEMS;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_MAX_ITEMS;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_MIN_ITEMS;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_MIN_LENGTH;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_NULL;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_OBJECT;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_ONE_OF;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_PROPERTIES;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_REQUIRED;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_SCHEMA;
@@ -64,56 +49,40 @@ import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_SCHEMA_IRI;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_STRING;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_TITLE;
 import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_TYPE;
-import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_UNIQUE_ITEMS;
-import static org.metadatacenter.model.ModelNodeNames.OSLC;
 import static org.metadatacenter.model.ModelNodeNames.OSLC_MODIFIED_BY;
-import static org.metadatacenter.model.ModelNodeNames.PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
-import static org.metadatacenter.model.ModelNodeNames.PAV;
 import static org.metadatacenter.model.ModelNodeNames.PAV_CREATED_BY;
 import static org.metadatacenter.model.ModelNodeNames.PAV_CREATED_ON;
 import static org.metadatacenter.model.ModelNodeNames.PAV_DERIVED_FROM;
 import static org.metadatacenter.model.ModelNodeNames.PAV_LAST_UPDATED_ON;
 import static org.metadatacenter.model.ModelNodeNames.PAV_PREVIOUS_VERSION;
 import static org.metadatacenter.model.ModelNodeNames.PAV_VERSION;
-import static org.metadatacenter.model.ModelNodeNames.RDFS;
 import static org.metadatacenter.model.ModelNodeNames.RDFS_LABEL;
-import static org.metadatacenter.model.ModelNodeNames.SCHEMA;
 import static org.metadatacenter.model.ModelNodeNames.SCHEMA_IS_BASED_ON;
 import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_DESCRIPTION;
 import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_IDENTIFIER;
 import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_NAME;
 import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_SCHEMA_VERSION;
-import static org.metadatacenter.model.ModelNodeNames.SKOS;
 import static org.metadatacenter.model.ModelNodeNames.SKOS_ALTLABEL;
 import static org.metadatacenter.model.ModelNodeNames.SKOS_NOTATION;
 import static org.metadatacenter.model.ModelNodeNames.SKOS_PREFLABEL;
-import static org.metadatacenter.model.ModelNodeNames.STATIC_FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
 import static org.metadatacenter.model.ModelNodeNames.UI;
 import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS;
 import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_MULTIPLE_CHOICE;
-import static org.metadatacenter.model.ModelNodeNames.XSD;
-import static org.metadatacenter.model.ModelNodeNames.XSD_DATETIME;
-import static org.metadatacenter.model.ModelNodeValues.OSLC_IRI;
-import static org.metadatacenter.model.ModelNodeValues.PAV_IRI;
-import static org.metadatacenter.model.ModelNodeValues.RDFS_IRI;
-import static org.metadatacenter.model.ModelNodeValues.SCHEMA_IRI;
-import static org.metadatacenter.model.ModelNodeValues.SKOS_IRI;
-import static org.metadatacenter.model.ModelNodeValues.XSD_IRI;
-import static org.metadatacenter.model.ModelNodeValues.XSD_STRING;
+
+import static org.metadatacenter.artifacts.model.renderer.JsonLdContextRenderers.*;
+import static org.metadatacenter.artifacts.model.renderer.JsonSchemaArtifactPropertyRenderers.*;
+import static org.metadatacenter.artifacts.model.renderer.JsonSchemaSpecRenderers.*;
 
 public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
-  private final ObjectMapper mapper;
-  private final DateTimeFormatter datetimeFormatter;
-  private final String datetimeFormat = "yyyy-MM-dd'T'HH:mm:ssXXX";
-  private final Version modelVersion = Version.fromString("1.6.0");
-
-  private final URI jsonSchemaSchemaUri = URI.create(JSON_SCHEMA_SCHEMA_IRI);
+  static final ObjectMapper MAPPER = new ObjectMapper()
+    .registerModule(new Jdk8Module())
+    .setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+  static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";
+  static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern(DATETIME_FORMAT);
+  static final Version MODEL_VERSION = Version.fromString("1.6.0");
+  static final URI JSON_SCHEMA_SCHEMA_URI = URI.create(JSON_SCHEMA_SCHEMA_IRI);
 
   public JsonArtifactRenderer() {
-    this.mapper = new ObjectMapper();
-    this.mapper.registerModule(new Jdk8Module());
-    this.mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
-    this.datetimeFormatter = DateTimeFormatter.ofPattern(datetimeFormat);
   }
 
   /**
@@ -151,13 +120,13 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
 
     rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
     addCoreJsonSchemaRendering(templateSchemaArtifact, rendering);
-    rendering.put(UI, mapper.valueToTree(templateSchemaArtifact.templateUi()));
+    rendering.put(UI, MAPPER.valueToTree(templateSchemaArtifact.templateUi()));
 
     rendering.put(JSON_SCHEMA_PROPERTIES,
         renderTemplateSchemaArtifactPropertiesJsonSchemaSpecification(templateSchemaArtifact));
 
     // TODO Put this list in ModelNodeNames
-    rendering.put(JSON_SCHEMA_REQUIRED, mapper.createArrayNode());
+    rendering.put(JSON_SCHEMA_REQUIRED, MAPPER.createArrayNode());
     rendering.withArray(JSON_SCHEMA_REQUIRED).add(JSON_LD_CONTEXT);
     rendering.withArray(JSON_SCHEMA_REQUIRED).add(JSON_LD_ID);
     rendering.withArray(JSON_SCHEMA_REQUIRED).add(SCHEMA_IS_BASED_ON);
@@ -215,7 +184,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
     addCoreSchemaOrgRendering(templateSchemaArtifact, rendering);
     addProvenanceRendering(templateSchemaArtifact, rendering);
     addVersionRendering(templateSchemaArtifact, rendering);
-    rendering.put(SCHEMA_ORG_SCHEMA_VERSION, modelVersion.toString());
+    rendering.put(SCHEMA_ORG_SCHEMA_VERSION, MODEL_VERSION.toString());
 
     if (templateSchemaArtifact.identifier().isPresent()) {
       String identifier = templateSchemaArtifact.identifier().get();
@@ -224,7 +193,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
       }
     }
 
-    rendering.put(JSON_SCHEMA_SCHEMA, renderUri(jsonSchemaSchemaUri));
+    rendering.put(JSON_SCHEMA_SCHEMA, renderUri(JSON_SCHEMA_SCHEMA_URI));
 
     return rendering;
   }
@@ -263,13 +232,13 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
     rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
     addCoreJsonSchemaRendering(elementSchemaArtifact, rendering);
 
-    rendering.put(UI, mapper.valueToTree(elementSchemaArtifact.elementUi()));
+    rendering.put(UI, MAPPER.valueToTree(elementSchemaArtifact.elementUi()));
 
     rendering.put(JSON_SCHEMA_PROPERTIES,
         renderElementSchemaArtifactPropertiesJsonSchemaSpecification(elementSchemaArtifact));
 
     // TODO Put this list in ModelNodeNames
-    rendering.put(JSON_SCHEMA_REQUIRED, mapper.createArrayNode());
+    rendering.put(JSON_SCHEMA_REQUIRED, MAPPER.createArrayNode());
     rendering.withArray(JSON_SCHEMA_REQUIRED).add(JSON_LD_CONTEXT);
     rendering.withArray(JSON_SCHEMA_REQUIRED).add(JSON_LD_ID);
 
@@ -314,7 +283,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
 
     addVersionRendering(elementSchemaArtifact, rendering);
 
-    rendering.put(SCHEMA_ORG_SCHEMA_VERSION, modelVersion.toString());
+    rendering.put(SCHEMA_ORG_SCHEMA_VERSION, MODEL_VERSION.toString());
 
     if (elementSchemaArtifact.hasAttributeValueField()) {
       rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES,
@@ -330,7 +299,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
       }
     }
 
-    rendering.put(JSON_SCHEMA_SCHEMA, renderUri(jsonSchemaSchemaUri));
+    rendering.put(JSON_SCHEMA_SCHEMA, renderUri(JSON_SCHEMA_SCHEMA_URI));
 
     return rendering;
   }
@@ -381,14 +350,14 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
 
     addCoreJsonSchemaRendering(fieldSchemaArtifact, rendering);
 
-    rendering.put(UI, mapper.valueToTree(fieldSchemaArtifact.fieldUi()));
+    rendering.put(UI, MAPPER.valueToTree(fieldSchemaArtifact.fieldUi()));
 
     // Static fields or attribute-value field have no value constraints field or JSON Schema properties specification
     if (!(fieldSchemaArtifact.isStatic() || fieldSchemaArtifact.isAttributeValue())) {
 
       if (fieldSchemaArtifact.valueConstraints().isPresent()) {
         ValueConstraints valueConstraints = fieldSchemaArtifact.valueConstraints().get();
-        ObjectNode valueConstraintRendering = mapper.valueToTree(valueConstraints);
+        ObjectNode valueConstraintRendering = MAPPER.valueToTree(valueConstraints);
 
         // We render multiple choice for list, checkbox and radio fields only (even if false)
         if (fieldSchemaArtifact.fieldUi().isCheckbox()) {
@@ -408,7 +377,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
         rendering.put(JSON_SCHEMA_PROPERTIES, renderIRIFieldArtifactPropertiesJsonSchemaSpecification());
       } else {
         rendering.put(JSON_SCHEMA_PROPERTIES, renderLiteralFieldArtifactPropertiesJsonSchemaSpecification());
-        rendering.put(JSON_SCHEMA_REQUIRED, mapper.createArrayNode());
+        rendering.put(JSON_SCHEMA_REQUIRED, MAPPER.createArrayNode());
         rendering.withArray(JSON_SCHEMA_REQUIRED).add(JSON_LD_VALUE);
 
         if (fieldSchemaArtifact.fieldUi().isTemporal() || fieldSchemaArtifact.fieldUi().isNumeric()) {
@@ -425,14 +394,14 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
     }
 
     if (!fieldSchemaArtifact.alternateLabels().isEmpty()) {
-      rendering.put(SKOS_ALTLABEL, mapper.createArrayNode());
+      rendering.put(SKOS_ALTLABEL, MAPPER.createArrayNode());
       for (String alternateLabel : fieldSchemaArtifact.alternateLabels()) {
         rendering.withArray(SKOS_ALTLABEL).add(alternateLabel);
       }
     }
 
     addVersionRendering(fieldSchemaArtifact, rendering);
-    rendering.put(SCHEMA_ORG_SCHEMA_VERSION, modelVersion.toString());
+    rendering.put(SCHEMA_ORG_SCHEMA_VERSION, MODEL_VERSION.toString());
 
     rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES, false);
 
@@ -443,7 +412,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
       }
     }
 
-    rendering.put(JSON_SCHEMA_SCHEMA, renderUri(jsonSchemaSchemaUri));
+    rendering.put(JSON_SCHEMA_SCHEMA, renderUri(JSON_SCHEMA_SCHEMA_URI));
 
     if (fieldSchemaArtifact.annotations().isPresent()) {
       rendering.put(ANNOTATIONS, renderAnnotations(fieldSchemaArtifact.annotations().get()));
@@ -551,7 +520,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
     ObjectNode rendering = renderParentInstanceArtifact(elementInstanceArtifact);
 
     if (!elementInstanceArtifact.jsonLdContext().isEmpty()) {
-      rendering.put(JSON_LD_CONTEXT, mapper.createObjectNode());
+      rendering.put(JSON_LD_CONTEXT, MAPPER.createObjectNode());
 
       for (var propertyMapping : elementInstanceArtifact.jsonLdContext().entrySet()) {
         String fieldKey = propertyMapping.getKey();
@@ -580,7 +549,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
   }
 
   private ObjectNode renderFieldInstanceArtifact(FieldInstanceArtifact fieldInstanceArtifact) {
-    ObjectNode objectNode = mapper.createObjectNode();
+    ObjectNode objectNode = MAPPER.createObjectNode();
 
     // TODO Use typesafe switch when available
     if (fieldInstanceArtifact instanceof IriFieldInstance) {
@@ -613,7 +582,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
     if (fieldInstanceArtifact.jsonLdTypes().size() == 1) {
       objectNode.put(JSON_LD_TYPE, renderPossiblyXsdPrefixedUri(fieldInstanceArtifact.jsonLdTypes().get(0)));
     } else if (fieldInstanceArtifact.jsonLdTypes().size() > 1) {
-      ArrayNode jsonLdTypesArrayNode = mapper.createArrayNode();
+      ArrayNode jsonLdTypesArrayNode = MAPPER.createArrayNode();
 
       for (int i = 0; i < fieldInstanceArtifact.jsonLdTypes().size(); i++) {
         jsonLdTypesArrayNode.add(renderPossiblyXsdPrefixedUri(fieldInstanceArtifact.jsonLdTypes().get(i)));
@@ -638,7 +607,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
   }
 
   private ObjectNode renderParentInstanceArtifact(ParentInstanceArtifact parentInstanceArtifact) {
-    ObjectNode rendering = mapper.createObjectNode();
+    ObjectNode rendering = MAPPER.createObjectNode();
 
     if (parentInstanceArtifact.jsonLdId().isPresent()) {
       rendering.put(JSON_LD_ID, renderUri(parentInstanceArtifact.jsonLdId().get()));
@@ -684,7 +653,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
             .get(childKey);
 
         Set<String> attributeValueInstanceFieldKeys = attributeValueFieldInstances.keySet();
-        ArrayNode attributeValueFieldInstanceKeysNode = mapper.createArrayNode();
+        ArrayNode attributeValueFieldInstanceKeysNode = MAPPER.createArrayNode();
 
         for (String attributeValueFieldInstanceKey : attributeValueInstanceFieldKeys) {
           attributeValueFieldInstanceKeysNode.add(attributeValueFieldInstanceKey);
@@ -713,7 +682,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
   }
 
   private ArrayNode renderFieldInstanceArtifacts(List<FieldInstanceArtifact> fieldInstanceArtifacts) {
-    ArrayNode arrayNode = mapper.createArrayNode();
+    ArrayNode arrayNode = MAPPER.createArrayNode();
 
     for (FieldInstanceArtifact fieldInstanceArtifact : fieldInstanceArtifacts) {
       arrayNode.add(renderFieldInstanceArtifact(fieldInstanceArtifact));
@@ -723,7 +692,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
   }
 
   private ArrayNode renderElementInstanceArtifacts(List<ElementInstanceArtifact> elementInstanceArtifacts) {
-    ArrayNode arrayNode = mapper.createArrayNode();
+    ArrayNode arrayNode = MAPPER.createArrayNode();
 
     for (ElementInstanceArtifact elementInstanceArtifact : elementInstanceArtifacts) {
       arrayNode.add(renderElementInstanceArtifact(elementInstanceArtifact));
@@ -809,7 +778,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * </pre>
    */
   private ObjectNode renderJsonLdArtifact(JsonLdArtifact jsonLdArtifact) {
-    ObjectNode rendering = mapper.createObjectNode();
+    ObjectNode rendering = MAPPER.createObjectNode();
 
     if (jsonLdArtifact.jsonLdId().isPresent()) {
       rendering.put(JSON_LD_ID, renderUri(jsonLdArtifact.jsonLdId().get()));
@@ -820,7 +789,7 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
     if (jsonLdArtifact.jsonLdTypes().size() == 1) {
       rendering.put(JSON_LD_TYPE, renderUri(jsonLdArtifact.jsonLdTypes().get(0)));
     } else if (jsonLdArtifact.jsonLdTypes().size() > 1) {
-      rendering.put(JSON_LD_TYPE, mapper.createArrayNode());
+      rendering.put(JSON_LD_TYPE, MAPPER.createArrayNode());
       for (URI jsonLdType : jsonLdArtifact.jsonLdTypes()) {
         rendering.withArray(JSON_LD_TYPE).add(renderUri(jsonLdType));
       }
@@ -895,22 +864,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * <p>
    * Note that no other additional properties are allowed due to "additionalProperties" being set to false.
    */
-  private ObjectNode renderAdditionalPropertiesForAttributeValueFieldJsonSchemaSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
-
-    rendering.put(JSON_SCHEMA_PROPERTIES, mapper.createObjectNode());
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(JSON_LD_VALUE, renderStringOrNullJsonSchemaTypeSpecification());
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(JSON_LD_TYPE, renderUriJsonSchemaTypeSpecification());
-    rendering.put(JSON_SCHEMA_REQUIRED, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(JSON_LD_VALUE);
-    rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES, false);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema specification for an additionalProperties field for a template or element containing
    * an attribute-value field
@@ -923,15 +876,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * }
    * </pre>
    */
-  private ObjectNode renderAdditionalPropertiesForAttributeValueFieldContextPropertiesJsonSchemaSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
-    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
-
-    return rendering;
-  }
-
   /**
    * Render a JSON Schema properties specification in a template schema artifact. First, this specification defines
    * the top-level fields that should be present in a template instance.
@@ -1017,34 +961,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * }
    * </pre>
    */
-  private ObjectNode renderTemplateSchemaArtifactPropertiesJsonSchemaSpecification(
-      TemplateSchemaArtifact templateSchemaArtifact) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_LD_CONTEXT,
-        renderTemplateSchemaArtifactContextPropertiesJsonSchemaSpecification(templateSchemaArtifact));
-
-    rendering.put(JSON_LD_ID, renderUriOrNullJsonSchemaTypeSpecification());
-
-    if (templateSchemaArtifact.instanceJsonLdType().isEmpty()) {
-      rendering.put(JSON_LD_TYPE, renderUriOrUriArrayJsonSchemaTypeSpecification(1, true));
-    } else {
-      URI instanceJsonLdType = templateSchemaArtifact.instanceJsonLdType().get();
-      rendering.put(JSON_LD_TYPE, renderUriOrUriArrayJsonSchemaTypeEnumSpecification(1, true, instanceJsonLdType));
-    }
-
-    rendering.put(SCHEMA_IS_BASED_ON, renderUriJsonSchemaTypeSpecification());
-    rendering.put(SCHEMA_ORG_NAME, renderStringJsonSchemaTypeSpecification(1));
-    rendering.put(SCHEMA_ORG_DESCRIPTION, renderStringJsonSchemaTypeSpecification(0));
-    rendering.put(PAV_DERIVED_FROM, renderUriJsonSchemaTypeSpecification());
-    rendering.put(PAV_CREATED_ON, renderDateTimeOrNullJsonSchemaTypeSpecification());
-    rendering.put(PAV_CREATED_BY, renderUriOrNullJsonSchemaTypeSpecification());
-    rendering.put(PAV_LAST_UPDATED_ON, renderDateTimeOrNullJsonSchemaTypeSpecification());
-    rendering.put(OSLC_MODIFIED_BY, renderUriOrNullJsonSchemaTypeSpecification());
-
-    return rendering;
-  }
-
   /**
    * Render a JSON Schema properties specification in an element schema artifact. First, this specification defines
    * the top-level fields that should be present in an element instance.
@@ -1095,24 +1011,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * }
    * </pre>
    */
-  private ObjectNode renderElementSchemaArtifactPropertiesJsonSchemaSpecification(
-      ElementSchemaArtifact elementSchemaArtifact) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_LD_CONTEXT,
-        renderElementSchemaArtifactContextPropertiesJsonSchemaSpecification(elementSchemaArtifact));
-    rendering.put(JSON_LD_ID, renderUriJsonSchemaTypeSpecification());
-
-    if (elementSchemaArtifact.instanceJsonLdType().isEmpty()) {
-      rendering.put(JSON_LD_TYPE, renderUriOrUriArrayJsonSchemaTypeSpecification(1, true));
-    } else {
-      URI instanceJsonLdType = elementSchemaArtifact.instanceJsonLdType().get();
-      rendering.put(JSON_LD_TYPE, renderUriOrUriArrayJsonSchemaTypeEnumSpecification(1, true, instanceJsonLdType));
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema specification for a @context properties specification in a template schema artifact
    * <p></p>
@@ -1166,77 +1064,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   }
    * </pre>
    */
-  private ObjectNode renderTemplateSchemaArtifactContextPropertiesJsonSchemaSpecification(
-      TemplateSchemaArtifact templateSchemaArtifact) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
-
-    rendering.put(JSON_SCHEMA_PROPERTIES, mapper.createObjectNode());
-
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(RDFS, renderJsonSchemaTypeUriEnumSpecification(RDFS_IRI));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(XSD, renderJsonSchemaTypeUriEnumSpecification(XSD_IRI));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(PAV, renderJsonSchemaTypeUriEnumSpecification(PAV_IRI));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(SCHEMA, renderJsonSchemaTypeUriEnumSpecification(SCHEMA_IRI));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(OSLC, renderJsonSchemaTypeUriEnumSpecification(OSLC_IRI));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(SKOS, renderJsonSchemaTypeUriEnumSpecification(SKOS_IRI));
-
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(RDFS_LABEL, renderJsonSchemaJsonLdDatatypeSpecification("xsd:string"));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(SCHEMA_IS_BASED_ON, renderJsonSchemaJsonLdDatatypeSpecification(JSON_LD_ID));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(SCHEMA_ORG_NAME, renderJsonSchemaJsonLdDatatypeSpecification("xsd:string"));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(SCHEMA_ORG_DESCRIPTION, renderJsonSchemaJsonLdDatatypeSpecification("xsd:string"));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(PAV_DERIVED_FROM, renderJsonSchemaJsonLdDatatypeSpecification(JSON_LD_ID));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(PAV_CREATED_ON, renderJsonSchemaJsonLdDatatypeSpecification("xsd:dateTime"));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(PAV_CREATED_BY, renderJsonSchemaJsonLdDatatypeSpecification(JSON_LD_ID));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(PAV_LAST_UPDATED_ON, renderJsonSchemaJsonLdDatatypeSpecification("xsd:dateTime"));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(OSLC_MODIFIED_BY, renderJsonSchemaJsonLdDatatypeSpecification(JSON_LD_ID));
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-        .put(SKOS_NOTATION, renderJsonSchemaJsonLdDatatypeSpecification("xsd:string"));
-
-    for (var entry : templateSchemaArtifact.getChildPropertyUris().entrySet()) {
-      String childKey = entry.getKey();
-      URI propertyUri = entry.getValue();
-      rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-          .put(childKey, renderJsonSchemaEnumSpecification(renderUri(propertyUri)));
-    }
-
-    rendering.put(JSON_SCHEMA_REQUIRED, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(XSD);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(PAV);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(SCHEMA);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(OSLC);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(SCHEMA_IS_BASED_ON);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(SCHEMA_ORG_NAME);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(SCHEMA_ORG_DESCRIPTION);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(PAV_CREATED_ON);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(PAV_CREATED_BY);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(PAV_LAST_UPDATED_ON);
-    rendering.withArray(JSON_SCHEMA_REQUIRED).add(OSLC_MODIFIED_BY);
-
-    for (String childKey : templateSchemaArtifact.getChildPropertyUris().keySet()) {
-      rendering.withArray(JSON_SCHEMA_REQUIRED).add(childKey);
-    }
-
-    if (templateSchemaArtifact.hasAttributeValueField()) {
-      rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES,
-          renderAdditionalPropertiesForAttributeValueFieldContextPropertiesJsonSchemaSpecification());
-    } else {
-      rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES, false);
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema specification for a @context properties specification in an element schema artifact
    * <p></p>
@@ -1263,38 +1090,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   }
    * </pre>
    */
-  private ObjectNode renderElementSchemaArtifactContextPropertiesJsonSchemaSpecification(
-      ElementSchemaArtifact elementSchemaArtifact) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
-
-    rendering.put(JSON_SCHEMA_PROPERTIES, mapper.createObjectNode());
-
-    for (var entry : elementSchemaArtifact.getChildPropertyUris().entrySet()) {
-      String childKey = entry.getKey();
-      URI propertyUri = entry.getValue();
-      rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
-          .put(childKey, renderJsonSchemaEnumSpecification(renderUri(propertyUri)));
-    }
-
-    if (!elementSchemaArtifact.getChildPropertyUris().isEmpty()) {
-      rendering.put(JSON_SCHEMA_REQUIRED, mapper.createArrayNode());
-      for (String childKey : elementSchemaArtifact.getChildPropertyUris().keySet()) {
-        rendering.withArray(JSON_SCHEMA_REQUIRED).add(childKey);
-      }
-    }
-
-    if (elementSchemaArtifact.hasAttributeValueField()) {
-      rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES,
-          renderAdditionalPropertiesForAttributeValueFieldContextPropertiesJsonSchemaSpecification());
-    } else {
-      rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES, false);
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema specification for a URI-formatted string value with a specific value.
    * <p></p>
@@ -1307,17 +1102,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   "http://purl.org/pav/"
    * </pre>
    */
-  private ObjectNode renderJsonSchemaTypeUriEnumSpecification(String uri) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
-    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
-    rendering.put(JSON_SCHEMA_ENUM, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_ENUM).add(uri);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema specification for an enum with a specific value.
    * <p></p>
@@ -1330,15 +1114,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   "http://purl.org/pav/"
    * </pre>
    */
-  private ObjectNode renderJsonSchemaEnumSpecification(String value) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_ENUM, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_ENUM).add(value);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema specification for a JSON-LD @type datatype specification
    * <p></p>
@@ -1351,22 +1126,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   { "@type": "xsd:string" }
    * </pre>
    */
-  private ObjectNode renderJsonSchemaJsonLdDatatypeSpecification(String datatype) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
-    rendering.put(JSON_SCHEMA_PROPERTIES, mapper.createObjectNode());
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(JSON_LD_TYPE, mapper.createObjectNode());
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).withObject("/" + JSON_LD_TYPE)
-        .put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).withObject("/" + JSON_LD_TYPE)
-        .put(JSON_SCHEMA_ENUM, mapper.createArrayNode());
-    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).withObject("/" + JSON_LD_TYPE).withArray(JSON_SCHEMA_ENUM)
-        .add(datatype);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON-LD @context for parent schema artifacts (i.e., templates and elements)
    * <p>
@@ -1386,26 +1145,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   }
    * </pre>
    */
-  private ObjectNode renderParentSchemaArtifactContextJsonLdSpecification(SchemaArtifact schemaArtifact) {
-    ObjectNode rendering = renderParentSchemaArtifactContextPrefixesJsonLdSpecification();
-
-    rendering.put(SCHEMA_ORG_NAME, renderXsdStringJsonLdSpecification());
-    rendering.put(SCHEMA_ORG_DESCRIPTION, renderXsdStringJsonLdSpecification());
-    rendering.put(PAV_CREATED_ON, renderXsdDateTimeJsonLdSpecification());
-    rendering.put(PAV_CREATED_BY, renderIriJsonLdSpecification());
-    rendering.put(PAV_LAST_UPDATED_ON, renderXsdDateTimeJsonLdSpecification());
-    rendering.put(OSLC_MODIFIED_BY, renderIriJsonLdSpecification());
-
-    if (schemaArtifact.language().isPresent()) {
-      String language = schemaArtifact.language().get();
-      if (!language.isEmpty()) {
-        rendering.put(JSON_LD_LANGUAGE, language);
-      }
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON-LD @context for template instance artifacts
    * <p>
@@ -1430,27 +1169,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   }
    * </pre>
    */
-  private ObjectNode renderTemplateInstanceArtifactContextJsonLdSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    for (var entry : INSTANCE_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
-      rendering.put(entry.getKey(), entry.getValue().toString());
-    }
-
-    rendering.put(RDFS_LABEL, renderXsdStringJsonLdSpecification());
-    rendering.put(SCHEMA_IS_BASED_ON, renderIriJsonLdSpecification());
-    rendering.put(SCHEMA_ORG_NAME, renderXsdStringJsonLdSpecification());
-    rendering.put(SCHEMA_ORG_DESCRIPTION, renderXsdStringJsonLdSpecification());
-    rendering.put(PAV_DERIVED_FROM, renderIriJsonLdSpecification());
-    rendering.put(PAV_CREATED_ON, renderXsdDateTimeJsonLdSpecification());
-    rendering.put(PAV_CREATED_BY, renderIriJsonLdSpecification());
-    rendering.put(PAV_LAST_UPDATED_ON, renderXsdDateTimeJsonLdSpecification());
-    rendering.put(OSLC_MODIFIED_BY, renderIriJsonLdSpecification());
-    rendering.put(SKOS_NOTATION, renderXsdStringJsonLdSpecification());
-
-    return rendering;
-  }
-
   /**
    * Generate JSON-LD @context prefix specification for parent schema artifacts
    * <p></p>
@@ -1465,16 +1183,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   }
    * </pre>
    */
-  private ObjectNode renderParentSchemaArtifactContextPrefixesJsonLdSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    for (var entry : PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
-      rendering.put(entry.getKey(), entry.getValue().toString());
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate JSON-LD @context prefix specification for field schema artifacts
    * <p></p>
@@ -1498,33 +1206,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   }
    * </pre>
    */
-  private ObjectNode renderFieldSchemaArtifactContextPrefixesJsonLdSpecification(
-      FieldSchemaArtifact fieldSchemaArtifact) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    for (var entry : FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
-      rendering.put(entry.getKey(), entry.getValue().toString());
-    }
-
-    rendering.put(SCHEMA_ORG_NAME, renderXsdStringJsonLdSpecification());
-    rendering.put(SCHEMA_ORG_DESCRIPTION, renderXsdStringJsonLdSpecification());
-    rendering.put(SKOS_PREFLABEL, renderXsdStringJsonLdSpecification());
-    rendering.put(SKOS_ALTLABEL, renderXsdStringJsonLdSpecification());
-    rendering.put(PAV_CREATED_ON, renderXsdDateTimeJsonLdSpecification());
-    rendering.put(PAV_CREATED_BY, renderIriJsonLdSpecification());
-    rendering.put(PAV_LAST_UPDATED_ON, renderXsdDateTimeJsonLdSpecification());
-    rendering.put(OSLC_MODIFIED_BY, renderIriJsonLdSpecification());
-
-    if (fieldSchemaArtifact.language().isPresent()) {
-      String language = fieldSchemaArtifact.language().get();
-      if (!language.isEmpty()) {
-        rendering.put(JSON_LD_LANGUAGE, language);
-      }
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate JSON-LD @context prefix specification for static field schema artifacts
    * <p></p>
@@ -1538,24 +1219,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   }
    * </pre>
    */
-  private ObjectNode renderStaticFieldSchemaArtifactContextPrefixesJsonLdSpecification(
-      FieldSchemaArtifact fieldSchemaArtifact) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    for (var entry : STATIC_FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
-      rendering.put(entry.getKey(), entry.getValue().toString());
-    }
-
-    if (fieldSchemaArtifact.language().isPresent()) {
-      String language = fieldSchemaArtifact.language().get();
-      if (!language.isEmpty()) {
-        rendering.put(JSON_LD_LANGUAGE, language);
-      }
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate JSON-LD @context prefix specification for instance artifacts
    * <p></p>
@@ -1571,16 +1234,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   }
    * </pre>
    */
-  private ObjectNode renderInstanceArtifactContextPrefixesJsonLdSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    for (var entry : INSTANCE_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
-      rendering.put(entry.getKey(), entry.getValue().toString());
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema properties specification for a label-valued field
    * <p></p>
@@ -1602,17 +1255,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * }
    * </pre>
    */
-  private ObjectNode renderLiteralFieldArtifactPropertiesJsonSchemaSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_LD_TYPE, renderUriJsonSchemaTypeSpecification());
-    rendering.put(RDFS_LABEL, renderStringOrNullJsonSchemaTypeSpecification());
-    rendering.put(JSON_LD_VALUE, renderStringOrNullJsonSchemaTypeSpecification());
-    rendering.put(JSON_LD_LANGUAGE, renderStringOrNullJsonSchemaTypeSpecification(1));
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema properties specification for a IRI-valued field
    * <p>
@@ -1632,17 +1274,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * }
    * </pre>
    */
-  private ObjectNode renderIRIFieldArtifactPropertiesJsonSchemaSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_LD_TYPE, renderUriJsonSchemaTypeSpecification());
-    rendering.put(JSON_LD_ID, renderUriJsonSchemaTypeSpecification());
-    rendering.put(RDFS_LABEL, renderStringOrNullJsonSchemaTypeSpecification());
-    rendering.put(SKOS_NOTATION, renderStringOrNullJsonSchemaTypeSpecification());
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema type specification for a string value
    * <p>
@@ -1651,18 +1282,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   { "type": "string", "minLength": [minLength] }
    * </pre>
    */
-  private ObjectNode renderStringJsonSchemaTypeSpecification(int minLength) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
-
-    if (minLength > 0) {
-      rendering.put(JSON_SCHEMA_MIN_LENGTH, minLength);
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema type specification for a string or null value
    * <p>
@@ -1671,16 +1290,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   { "type": [ "string", "null" ] }
    * </pre>
    */
-  private ObjectNode renderStringOrNullJsonSchemaTypeSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_STRING);
-    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_NULL);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema type specification for a string or null value
    * <p>
@@ -1689,20 +1298,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   { "type": [ "string", "null" ], "minLength": [minLength] }
    * </pre>
    */
-  private ObjectNode renderStringOrNullJsonSchemaTypeSpecification(int minLength) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_STRING);
-    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_NULL);
-
-    if (minLength > 0) {
-      rendering.put(JSON_SCHEMA_MIN_LENGTH, minLength);
-    }
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema type specification for a URI-formatted string or null value
    * <p>
@@ -1711,18 +1306,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * //   { "type": [ "string", "null" ], "format": "uri" },
    * </pre>
    */
-  private ObjectNode renderUriOrNullJsonSchemaTypeSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_STRING);
-    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_NULL);
-
-    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON-LD @type specification for an xsd:string
    * <p>
@@ -1731,14 +1314,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   { "@type": "xsd:string" }
    * </pre>
    */
-  private ObjectNode renderXsdStringJsonLdSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_LD_TYPE, XSD_STRING);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON-LD @type specification for an xsd:dateTime
    * <p>
@@ -1747,14 +1322,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   { "@type": "xsd:dateTime" }
    * </pre>
    */
-  private ObjectNode renderXsdDateTimeJsonLdSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_LD_TYPE, XSD_DATETIME);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON-LD @type specification for an IRI
    * <p>
@@ -1763,14 +1330,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   { "@type": "@id" }
    * </pre>
    */
-  private ObjectNode renderIriJsonLdSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_LD_TYPE, JSON_LD_ID);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema type specification for a datetime-formatted string or null value
    * <p>
@@ -1779,17 +1338,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *  { "type": [ "string", "null" ], "format": "date-time" },
    * </pre>
    */
-  private ObjectNode renderDateTimeOrNullJsonSchemaTypeSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_STRING);
-    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_NULL);
-    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_DATE_TIME);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema type specification for a URI-formatted string
    * <p>
@@ -1798,15 +1346,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *   { "type": "string", "format": "uri" }
    * </pre>
    */
-  private ObjectNode renderUriJsonSchemaTypeSpecification() {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
-    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema specification for URI-formatted string or URI-formatted string array
    * <p>
@@ -1820,16 +1359,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * }
    * </pre>
    */
-  private ObjectNode renderUriOrUriArrayJsonSchemaTypeSpecification(int minItems, boolean uniqueItems) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_ONE_OF, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_ONE_OF).add(renderUriJsonSchemaTypeSpecification());
-    rendering.withArray(JSON_SCHEMA_ONE_OF).add(renderUriArrayJsonSchemaTypeSpecification(minItems, uniqueItems));
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema specification for a specific URI as a single value or as a value in an array
    * <p>
@@ -1851,17 +1380,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    *     }
    * </pre>
    */
-  private ObjectNode renderUriOrUriArrayJsonSchemaTypeEnumSpecification(int minItems, boolean uniqueItems, URI uri) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_ONE_OF, mapper.createArrayNode());
-    rendering.withArray(JSON_SCHEMA_ONE_OF).add(renderJsonSchemaTypeUriEnumSpecification(uri.toString()));
-    rendering.withArray(JSON_SCHEMA_ONE_OF)
-        .add(renderUriArrayJsonSchemaTypeEnumSpecification(minItems, uniqueItems, uri));
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema type specification for URI-formatted string array
    * <p>
@@ -1874,19 +1392,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * }
    * </pre>
    */
-  private ObjectNode renderUriArrayJsonSchemaTypeSpecification(int minItems, boolean uniqueItems) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_ARRAY);
-    rendering.put(JSON_SCHEMA_MIN_ITEMS, minItems);
-    rendering.put(JSON_SCHEMA_ITEMS, mapper.createObjectNode());
-    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
-    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
-    rendering.put(JSON_SCHEMA_UNIQUE_ITEMS, uniqueItems);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema type specification for an array containing a specific URI
    * <p>
@@ -1899,21 +1404,6 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * }
    * </pre>
    */
-  private ObjectNode renderUriArrayJsonSchemaTypeEnumSpecification(int minItems, boolean uniqueItems, URI uri) {
-    ObjectNode rendering = mapper.createObjectNode();
-
-    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_ARRAY);
-    rendering.put(JSON_SCHEMA_MIN_ITEMS, minItems);
-    rendering.put(JSON_SCHEMA_ITEMS, mapper.createObjectNode());
-    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
-    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
-    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_ENUM, mapper.createArrayNode());
-    rendering.withObject("/" + JSON_SCHEMA_ITEMS).withArray(JSON_SCHEMA_ENUM).add(uri.toString());
-    rendering.put(JSON_SCHEMA_UNIQUE_ITEMS, uniqueItems);
-
-    return rendering;
-  }
-
   /**
    * Generate a JSON Schema array specification wrapping a supplied JSON Schema specification
    * <p>
@@ -1922,29 +1412,8 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
    * { "type": "array", "minItems": [minItems], "maxItems": [maxItems], "items": [wrappedRendering] }
    * </pre>
    */
-  private ObjectNode renderJsonSchemaArrayWrapperSpecification(ObjectNode wrappedRendering, Optional<Integer> minItems,
-                                                               Optional<Integer> maxItems) {
-    ObjectNode wrapperRendering = mapper.createObjectNode();
-
-    wrapperRendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_ARRAY);
-
-    if (minItems.isPresent()) {
-      wrapperRendering.put(JSON_SCHEMA_MIN_ITEMS, minItems.get());
-    } else {
-      wrapperRendering.put(JSON_SCHEMA_MIN_ITEMS, 0);
-    }
-
-    if (maxItems.isPresent()) {
-      wrapperRendering.put(JSON_SCHEMA_MAX_ITEMS, maxItems.get());
-    }
-
-    wrapperRendering.put(JSON_SCHEMA_ITEMS, wrappedRendering);
-
-    return wrapperRendering;
-  }
-
   private ObjectNode renderAnnotations(Annotations annotations) {
-    ObjectNode rendering = mapper.createObjectNode();
+    ObjectNode rendering = MAPPER.createObjectNode();
 
     for (Map.Entry<String, AnnotationValue> annotationValueEntry : annotations.annotations().entrySet()) {
       String annotationName = annotationValueEntry.getKey();
@@ -1953,12 +1422,12 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
       // TODO Use typesafe switch when available
       if (annotationValue instanceof LiteralAnnotationValue) {
         LiteralAnnotationValue literalAnnotationValue = (LiteralAnnotationValue) annotationValue;
-        ObjectNode annotationValueNode = mapper.createObjectNode();
+        ObjectNode annotationValueNode = MAPPER.createObjectNode();
         annotationValueNode.put(JSON_LD_VALUE, literalAnnotationValue.getValue());
         rendering.put(annotationName, annotationValueNode);
       } else if (annotationValue instanceof IriAnnotationValue) {
         IriAnnotationValue iriAnnotationValue = (IriAnnotationValue) annotationValue;
-        ObjectNode annotationValueNode = mapper.createObjectNode();
+        ObjectNode annotationValueNode = MAPPER.createObjectNode();
         annotationValueNode.put(JSON_LD_ID, renderUri(iriAnnotationValue.getValue()));
         rendering.put(annotationName, annotationValueNode);
       }
@@ -1967,19 +1436,4 @@ public class JsonArtifactRenderer implements ArtifactRenderer<ObjectNode> {
     return rendering;
   }
 
-  private String renderOffsetDateTime(OffsetDateTime offsetDateTime) {
-    return offsetDateTime.format(datetimeFormatter);
-  }
-
-  private String renderUri(URI uri) {
-    return uri.toString();
-  }
-
-  private String renderPossiblyXsdPrefixedUri(URI uri) {
-    if (XsdDatatype.isKnownXsdDatatypeUri(uri)) {
-      return XsdDatatype.fromUri(uri).getText(); // We render the prefixed form of XSD datatypes
-    } else {
-      return uri.toString();
-    }
-  }
 }

--- a/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonLdContextRenderers.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonLdContextRenderers.java
@@ -1,0 +1,128 @@
+package org.metadatacenter.artifacts.model.renderer;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.metadatacenter.artifacts.model.core.FieldSchemaArtifact;
+import org.metadatacenter.artifacts.model.core.SchemaArtifact;
+
+
+import static org.metadatacenter.artifacts.model.renderer.JsonArtifactRenderer.MAPPER;
+import static org.metadatacenter.artifacts.model.renderer.JsonLdContextRenderers.*;
+import static org.metadatacenter.artifacts.model.renderer.JsonSchemaArtifactPropertyRenderers.*;
+import static org.metadatacenter.artifacts.model.renderer.JsonSchemaSpecRenderers.*;
+import static org.metadatacenter.model.ModelNodeNames.*;
+
+final class JsonLdContextRenderers {
+  private JsonLdContextRenderers() {}
+
+  public static ObjectNode renderParentSchemaArtifactContextJsonLdSpecification(SchemaArtifact schemaArtifact) {
+    ObjectNode rendering = renderParentSchemaArtifactContextPrefixesJsonLdSpecification();
+
+    rendering.put(SCHEMA_ORG_NAME, renderXsdStringJsonLdSpecification());
+    rendering.put(SCHEMA_ORG_DESCRIPTION, renderXsdStringJsonLdSpecification());
+    rendering.put(PAV_CREATED_ON, renderXsdDateTimeJsonLdSpecification());
+    rendering.put(PAV_CREATED_BY, renderIriJsonLdSpecification());
+    rendering.put(PAV_LAST_UPDATED_ON, renderXsdDateTimeJsonLdSpecification());
+    rendering.put(OSLC_MODIFIED_BY, renderIriJsonLdSpecification());
+
+    if (schemaArtifact.language().isPresent()) {
+      String language = schemaArtifact.language().get();
+      if (!language.isEmpty()) {
+        rendering.put(JSON_LD_LANGUAGE, language);
+      }
+    }
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderTemplateInstanceArtifactContextJsonLdSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    for (var entry : INSTANCE_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
+      rendering.put(entry.getKey(), entry.getValue().toString());
+    }
+
+    rendering.put(RDFS_LABEL, renderXsdStringJsonLdSpecification());
+    rendering.put(SCHEMA_IS_BASED_ON, renderIriJsonLdSpecification());
+    rendering.put(SCHEMA_ORG_NAME, renderXsdStringJsonLdSpecification());
+    rendering.put(SCHEMA_ORG_DESCRIPTION, renderXsdStringJsonLdSpecification());
+    rendering.put(PAV_DERIVED_FROM, renderIriJsonLdSpecification());
+    rendering.put(PAV_CREATED_ON, renderXsdDateTimeJsonLdSpecification());
+    rendering.put(PAV_CREATED_BY, renderIriJsonLdSpecification());
+    rendering.put(PAV_LAST_UPDATED_ON, renderXsdDateTimeJsonLdSpecification());
+    rendering.put(OSLC_MODIFIED_BY, renderIriJsonLdSpecification());
+    rendering.put(SKOS_NOTATION, renderXsdStringJsonLdSpecification());
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderParentSchemaArtifactContextPrefixesJsonLdSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    for (var entry : PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
+      rendering.put(entry.getKey(), entry.getValue().toString());
+    }
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderFieldSchemaArtifactContextPrefixesJsonLdSpecification(
+      FieldSchemaArtifact fieldSchemaArtifact) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    for (var entry : FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
+      rendering.put(entry.getKey(), entry.getValue().toString());
+    }
+
+    rendering.put(SCHEMA_ORG_NAME, renderXsdStringJsonLdSpecification());
+    rendering.put(SCHEMA_ORG_DESCRIPTION, renderXsdStringJsonLdSpecification());
+    rendering.put(SKOS_PREFLABEL, renderXsdStringJsonLdSpecification());
+    rendering.put(SKOS_ALTLABEL, renderXsdStringJsonLdSpecification());
+    rendering.put(PAV_CREATED_ON, renderXsdDateTimeJsonLdSpecification());
+    rendering.put(PAV_CREATED_BY, renderIriJsonLdSpecification());
+    rendering.put(PAV_LAST_UPDATED_ON, renderXsdDateTimeJsonLdSpecification());
+    rendering.put(OSLC_MODIFIED_BY, renderIriJsonLdSpecification());
+
+    if (fieldSchemaArtifact.language().isPresent()) {
+      String language = fieldSchemaArtifact.language().get();
+      if (!language.isEmpty()) {
+        rendering.put(JSON_LD_LANGUAGE, language);
+      }
+    }
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderStaticFieldSchemaArtifactContextPrefixesJsonLdSpecification(
+      FieldSchemaArtifact fieldSchemaArtifact) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    for (var entry : STATIC_FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
+      rendering.put(entry.getKey(), entry.getValue().toString());
+    }
+
+    if (fieldSchemaArtifact.language().isPresent()) {
+      String language = fieldSchemaArtifact.language().get();
+      if (!language.isEmpty()) {
+        rendering.put(JSON_LD_LANGUAGE, language);
+      }
+    }
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderInstanceArtifactContextPrefixesJsonLdSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    for (var entry : INSTANCE_ARTIFACT_CONTEXT_PREFIX_MAPPINGS.entrySet()) {
+      rendering.put(entry.getKey(), entry.getValue().toString());
+    }
+
+    return rendering;
+  }
+
+}

--- a/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonSchemaArtifactPropertyRenderers.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonSchemaArtifactPropertyRenderers.java
@@ -1,0 +1,203 @@
+package org.metadatacenter.artifacts.model.renderer;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.metadatacenter.artifacts.model.core.ElementSchemaArtifact;
+import org.metadatacenter.artifacts.model.core.TemplateSchemaArtifact;
+
+import java.net.URI;
+
+import static org.metadatacenter.artifacts.model.renderer.JsonArtifactRenderer.MAPPER;
+import static org.metadatacenter.artifacts.model.renderer.JsonLdContextRenderers.*;
+import static org.metadatacenter.artifacts.model.renderer.JsonSchemaArtifactPropertyRenderers.*;
+import static org.metadatacenter.artifacts.model.renderer.JsonSchemaSpecRenderers.*;
+import static org.metadatacenter.model.ModelNodeNames.*;
+import static org.metadatacenter.model.ModelNodeValues.OSLC_IRI;
+import static org.metadatacenter.model.ModelNodeValues.PAV_IRI;
+import static org.metadatacenter.model.ModelNodeValues.RDFS_IRI;
+import static org.metadatacenter.model.ModelNodeValues.SCHEMA_IRI;
+import static org.metadatacenter.model.ModelNodeValues.SKOS_IRI;
+import static org.metadatacenter.model.ModelNodeValues.XSD_IRI;
+
+final class JsonSchemaArtifactPropertyRenderers {
+  private JsonSchemaArtifactPropertyRenderers() {}
+
+  public static ObjectNode renderAdditionalPropertiesForAttributeValueFieldJsonSchemaSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
+
+    rendering.put(JSON_SCHEMA_PROPERTIES, MAPPER.createObjectNode());
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(JSON_LD_VALUE, renderStringOrNullJsonSchemaTypeSpecification());
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(JSON_LD_TYPE, renderUriJsonSchemaTypeSpecification());
+    rendering.put(JSON_SCHEMA_REQUIRED, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(JSON_LD_VALUE);
+    rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES, false);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderAdditionalPropertiesForAttributeValueFieldContextPropertiesJsonSchemaSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
+    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderTemplateSchemaArtifactPropertiesJsonSchemaSpecification(
+      TemplateSchemaArtifact templateSchemaArtifact) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_LD_CONTEXT,
+        renderTemplateSchemaArtifactContextPropertiesJsonSchemaSpecification(templateSchemaArtifact));
+
+    rendering.put(JSON_LD_ID, renderUriOrNullJsonSchemaTypeSpecification());
+
+    if (templateSchemaArtifact.instanceJsonLdType().isEmpty()) {
+      rendering.put(JSON_LD_TYPE, renderUriOrUriArrayJsonSchemaTypeSpecification(1, true));
+    } else {
+      URI instanceJsonLdType = templateSchemaArtifact.instanceJsonLdType().get();
+      rendering.put(JSON_LD_TYPE, renderUriOrUriArrayJsonSchemaTypeEnumSpecification(1, true, instanceJsonLdType));
+    }
+
+    rendering.put(SCHEMA_IS_BASED_ON, renderUriJsonSchemaTypeSpecification());
+    rendering.put(SCHEMA_ORG_NAME, renderStringJsonSchemaTypeSpecification(1));
+    rendering.put(SCHEMA_ORG_DESCRIPTION, renderStringJsonSchemaTypeSpecification(0));
+    rendering.put(PAV_DERIVED_FROM, renderUriJsonSchemaTypeSpecification());
+    rendering.put(PAV_CREATED_ON, renderDateTimeOrNullJsonSchemaTypeSpecification());
+    rendering.put(PAV_CREATED_BY, renderUriOrNullJsonSchemaTypeSpecification());
+    rendering.put(PAV_LAST_UPDATED_ON, renderDateTimeOrNullJsonSchemaTypeSpecification());
+    rendering.put(OSLC_MODIFIED_BY, renderUriOrNullJsonSchemaTypeSpecification());
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderElementSchemaArtifactPropertiesJsonSchemaSpecification(
+      ElementSchemaArtifact elementSchemaArtifact) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_LD_CONTEXT,
+        renderElementSchemaArtifactContextPropertiesJsonSchemaSpecification(elementSchemaArtifact));
+    rendering.put(JSON_LD_ID, renderUriJsonSchemaTypeSpecification());
+
+    if (elementSchemaArtifact.instanceJsonLdType().isEmpty()) {
+      rendering.put(JSON_LD_TYPE, renderUriOrUriArrayJsonSchemaTypeSpecification(1, true));
+    } else {
+      URI instanceJsonLdType = elementSchemaArtifact.instanceJsonLdType().get();
+      rendering.put(JSON_LD_TYPE, renderUriOrUriArrayJsonSchemaTypeEnumSpecification(1, true, instanceJsonLdType));
+    }
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderTemplateSchemaArtifactContextPropertiesJsonSchemaSpecification(
+      TemplateSchemaArtifact templateSchemaArtifact) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
+
+    rendering.put(JSON_SCHEMA_PROPERTIES, MAPPER.createObjectNode());
+
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(RDFS, renderJsonSchemaTypeUriEnumSpecification(RDFS_IRI));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(XSD, renderJsonSchemaTypeUriEnumSpecification(XSD_IRI));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(PAV, renderJsonSchemaTypeUriEnumSpecification(PAV_IRI));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(SCHEMA, renderJsonSchemaTypeUriEnumSpecification(SCHEMA_IRI));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(OSLC, renderJsonSchemaTypeUriEnumSpecification(OSLC_IRI));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(SKOS, renderJsonSchemaTypeUriEnumSpecification(SKOS_IRI));
+
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(RDFS_LABEL, renderJsonSchemaJsonLdDatatypeSpecification("xsd:string"));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(SCHEMA_IS_BASED_ON, renderJsonSchemaJsonLdDatatypeSpecification(JSON_LD_ID));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(SCHEMA_ORG_NAME, renderJsonSchemaJsonLdDatatypeSpecification("xsd:string"));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(SCHEMA_ORG_DESCRIPTION, renderJsonSchemaJsonLdDatatypeSpecification("xsd:string"));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(PAV_DERIVED_FROM, renderJsonSchemaJsonLdDatatypeSpecification(JSON_LD_ID));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(PAV_CREATED_ON, renderJsonSchemaJsonLdDatatypeSpecification("xsd:dateTime"));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(PAV_CREATED_BY, renderJsonSchemaJsonLdDatatypeSpecification(JSON_LD_ID));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(PAV_LAST_UPDATED_ON, renderJsonSchemaJsonLdDatatypeSpecification("xsd:dateTime"));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(OSLC_MODIFIED_BY, renderJsonSchemaJsonLdDatatypeSpecification(JSON_LD_ID));
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+        .put(SKOS_NOTATION, renderJsonSchemaJsonLdDatatypeSpecification("xsd:string"));
+
+    for (var entry : templateSchemaArtifact.getChildPropertyUris().entrySet()) {
+      String childKey = entry.getKey();
+      URI propertyUri = entry.getValue();
+      rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+          .put(childKey, renderJsonSchemaEnumSpecification(renderUri(propertyUri)));
+    }
+
+    rendering.put(JSON_SCHEMA_REQUIRED, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(XSD);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(PAV);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(SCHEMA);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(OSLC);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(SCHEMA_IS_BASED_ON);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(SCHEMA_ORG_NAME);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(SCHEMA_ORG_DESCRIPTION);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(PAV_CREATED_ON);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(PAV_CREATED_BY);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(PAV_LAST_UPDATED_ON);
+    rendering.withArray(JSON_SCHEMA_REQUIRED).add(OSLC_MODIFIED_BY);
+
+    for (String childKey : templateSchemaArtifact.getChildPropertyUris().keySet()) {
+      rendering.withArray(JSON_SCHEMA_REQUIRED).add(childKey);
+    }
+
+    if (templateSchemaArtifact.hasAttributeValueField()) {
+      rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES,
+          renderAdditionalPropertiesForAttributeValueFieldContextPropertiesJsonSchemaSpecification());
+    } else {
+      rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES, false);
+    }
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderElementSchemaArtifactContextPropertiesJsonSchemaSpecification(
+      ElementSchemaArtifact elementSchemaArtifact) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
+
+    rendering.put(JSON_SCHEMA_PROPERTIES, MAPPER.createObjectNode());
+
+    for (var entry : elementSchemaArtifact.getChildPropertyUris().entrySet()) {
+      String childKey = entry.getKey();
+      URI propertyUri = entry.getValue();
+      rendering.withObject("/" + JSON_SCHEMA_PROPERTIES)
+          .put(childKey, renderJsonSchemaEnumSpecification(renderUri(propertyUri)));
+    }
+
+    if (!elementSchemaArtifact.getChildPropertyUris().isEmpty()) {
+      rendering.put(JSON_SCHEMA_REQUIRED, MAPPER.createArrayNode());
+      for (String childKey : elementSchemaArtifact.getChildPropertyUris().keySet()) {
+        rendering.withArray(JSON_SCHEMA_REQUIRED).add(childKey);
+      }
+    }
+
+    if (elementSchemaArtifact.hasAttributeValueField()) {
+      rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES,
+          renderAdditionalPropertiesForAttributeValueFieldContextPropertiesJsonSchemaSpecification());
+    } else {
+      rendering.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES, false);
+    }
+
+    return rendering;
+  }
+
+}

--- a/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonSchemaSpecRenderers.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/renderer/JsonSchemaSpecRenderers.java
@@ -1,0 +1,278 @@
+package org.metadatacenter.artifacts.model.renderer;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.metadatacenter.artifacts.model.core.fields.XsdDatatype;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.metadatacenter.artifacts.model.renderer.JsonArtifactRenderer.DATETIME_FORMATTER;
+import static org.metadatacenter.artifacts.model.renderer.JsonArtifactRenderer.MAPPER;
+import static org.metadatacenter.artifacts.model.renderer.JsonLdContextRenderers.*;
+import static org.metadatacenter.artifacts.model.renderer.JsonSchemaArtifactPropertyRenderers.*;
+import static org.metadatacenter.artifacts.model.renderer.JsonSchemaSpecRenderers.*;
+import static org.metadatacenter.model.ModelNodeNames.*;
+import static org.metadatacenter.model.ModelNodeValues.XSD_STRING;
+
+final class JsonSchemaSpecRenderers {
+  private JsonSchemaSpecRenderers() {}
+
+  public static ObjectNode renderJsonSchemaTypeUriEnumSpecification(String uri) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
+    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
+    rendering.put(JSON_SCHEMA_ENUM, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_ENUM).add(uri);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderJsonSchemaEnumSpecification(String value) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_ENUM, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_ENUM).add(value);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderJsonSchemaJsonLdDatatypeSpecification(String datatype) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
+    rendering.put(JSON_SCHEMA_PROPERTIES, MAPPER.createObjectNode());
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).put(JSON_LD_TYPE, MAPPER.createObjectNode());
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).withObject("/" + JSON_LD_TYPE)
+        .put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).withObject("/" + JSON_LD_TYPE)
+        .put(JSON_SCHEMA_ENUM, MAPPER.createArrayNode());
+    rendering.withObject("/" + JSON_SCHEMA_PROPERTIES).withObject("/" + JSON_LD_TYPE).withArray(JSON_SCHEMA_ENUM)
+        .add(datatype);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderLiteralFieldArtifactPropertiesJsonSchemaSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_LD_TYPE, renderUriJsonSchemaTypeSpecification());
+    rendering.put(RDFS_LABEL, renderStringOrNullJsonSchemaTypeSpecification());
+    rendering.put(JSON_LD_VALUE, renderStringOrNullJsonSchemaTypeSpecification());
+    rendering.put(JSON_LD_LANGUAGE, renderStringOrNullJsonSchemaTypeSpecification(1));
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderIRIFieldArtifactPropertiesJsonSchemaSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_LD_TYPE, renderUriJsonSchemaTypeSpecification());
+    rendering.put(JSON_LD_ID, renderUriJsonSchemaTypeSpecification());
+    rendering.put(RDFS_LABEL, renderStringOrNullJsonSchemaTypeSpecification());
+    rendering.put(SKOS_NOTATION, renderStringOrNullJsonSchemaTypeSpecification());
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderStringJsonSchemaTypeSpecification(int minLength) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
+
+    if (minLength > 0) {
+      rendering.put(JSON_SCHEMA_MIN_LENGTH, minLength);
+    }
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderStringOrNullJsonSchemaTypeSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_STRING);
+    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_NULL);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderStringOrNullJsonSchemaTypeSpecification(int minLength) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_STRING);
+    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_NULL);
+
+    if (minLength > 0) {
+      rendering.put(JSON_SCHEMA_MIN_LENGTH, minLength);
+    }
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderUriOrNullJsonSchemaTypeSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_STRING);
+    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_NULL);
+
+    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderXsdStringJsonLdSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_LD_TYPE, XSD_STRING);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderXsdDateTimeJsonLdSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_LD_TYPE, XSD_DATETIME);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderIriJsonLdSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_LD_TYPE, JSON_LD_ID);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderDateTimeOrNullJsonSchemaTypeSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_STRING);
+    rendering.withArray(JSON_SCHEMA_TYPE).add(JSON_SCHEMA_NULL);
+    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_DATE_TIME);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderUriJsonSchemaTypeSpecification() {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
+    rendering.put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderUriOrUriArrayJsonSchemaTypeSpecification(int minItems, boolean uniqueItems) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_ONE_OF, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_ONE_OF).add(renderUriJsonSchemaTypeSpecification());
+    rendering.withArray(JSON_SCHEMA_ONE_OF).add(renderUriArrayJsonSchemaTypeSpecification(minItems, uniqueItems));
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderUriOrUriArrayJsonSchemaTypeEnumSpecification(int minItems, boolean uniqueItems, URI uri) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_ONE_OF, MAPPER.createArrayNode());
+    rendering.withArray(JSON_SCHEMA_ONE_OF).add(renderJsonSchemaTypeUriEnumSpecification(uri.toString()));
+    rendering.withArray(JSON_SCHEMA_ONE_OF)
+        .add(renderUriArrayJsonSchemaTypeEnumSpecification(minItems, uniqueItems, uri));
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderUriArrayJsonSchemaTypeSpecification(int minItems, boolean uniqueItems) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_ARRAY);
+    rendering.put(JSON_SCHEMA_MIN_ITEMS, minItems);
+    rendering.put(JSON_SCHEMA_ITEMS, MAPPER.createObjectNode());
+    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
+    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
+    rendering.put(JSON_SCHEMA_UNIQUE_ITEMS, uniqueItems);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderUriArrayJsonSchemaTypeEnumSpecification(int minItems, boolean uniqueItems, URI uri) {
+    ObjectNode rendering = MAPPER.createObjectNode();
+
+    rendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_ARRAY);
+    rendering.put(JSON_SCHEMA_MIN_ITEMS, minItems);
+    rendering.put(JSON_SCHEMA_ITEMS, MAPPER.createObjectNode());
+    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_TYPE, JSON_SCHEMA_STRING);
+    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_FORMAT, JSON_SCHEMA_FORMAT_URI);
+    rendering.withObject("/" + JSON_SCHEMA_ITEMS).put(JSON_SCHEMA_ENUM, MAPPER.createArrayNode());
+    rendering.withObject("/" + JSON_SCHEMA_ITEMS).withArray(JSON_SCHEMA_ENUM).add(uri.toString());
+    rendering.put(JSON_SCHEMA_UNIQUE_ITEMS, uniqueItems);
+
+    return rendering;
+  }
+
+
+  public static ObjectNode renderJsonSchemaArrayWrapperSpecification(ObjectNode wrappedRendering, Optional<Integer> minItems,
+                                                               Optional<Integer> maxItems) {
+    ObjectNode wrapperRendering = MAPPER.createObjectNode();
+
+    wrapperRendering.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_ARRAY);
+
+    if (minItems.isPresent()) {
+      wrapperRendering.put(JSON_SCHEMA_MIN_ITEMS, minItems.get());
+    } else {
+      wrapperRendering.put(JSON_SCHEMA_MIN_ITEMS, 0);
+    }
+
+    if (maxItems.isPresent()) {
+      wrapperRendering.put(JSON_SCHEMA_MAX_ITEMS, maxItems.get());
+    }
+
+    wrapperRendering.put(JSON_SCHEMA_ITEMS, wrappedRendering);
+
+    return wrapperRendering;
+  }
+
+
+  public static String renderOffsetDateTime(OffsetDateTime offsetDateTime) {
+    return offsetDateTime.format(DATETIME_FORMATTER);
+  }
+
+
+  public static String renderUri(URI uri) {
+    return uri.toString();
+  }
+
+
+  public static String renderPossiblyXsdPrefixedUri(URI uri) {
+    if (XsdDatatype.isKnownXsdDatatypeUri(uri)) {
+      return XsdDatatype.fromUri(uri).getText(); // We render the prefixed form of XSD datatypes
+    } else {
+      return uri.toString();
+    }
+  }
+
+}


### PR DESCRIPTION
Renderer half of item 6. Mirror of [#38](https://github.com/metadatacenter/cedar-artifact-library/pull/38) (the Reader split).

## Summary

\`JsonArtifactRenderer.java\` was 1985 LOC. This PR extracts three package-private helper classes:

| Helper | Methods | LOC | What's in it |
|---|---|---|---|
| \`JsonSchemaSpecRenderers\` | 22 | 278 | Leaf-level JSON Schema / JSON-LD type-spec builders: \`renderUri\`, \`renderOffsetDateTime\`, the various \`render{String,Uri,DateTime,XsdString,...}*Specification\` helpers, plus the literal/IRI field-properties helpers. |
| \`JsonLdContextRenderers\` | 6 | 128 | JSON-LD \`@context\` rendering for parent schema artifacts (prefix mappings, context-property specs) and for instance artifacts. |
| \`JsonSchemaArtifactPropertyRenderers\` | 6 | 203 | The big top-level template/element schema properties renderers, plus the attribute-value field special cases. |

### A wrinkle: state

Unlike the Reader, the Renderer had five instance fields (\`mapper\`, \`datetimeFormatter\`, \`datetimeFormat\`, \`modelVersion\`, \`jsonSchemaSchemaUri\`) used 72 times across the file. To make \`import static\` work cleanly across the helper boundary, these become package-private \`static final\` constants on \`JsonArtifactRenderer\`: \`MAPPER\`, \`DATETIME_FORMATTER\`, \`DATETIME_FORMAT\`, \`MODEL_VERSION\`, \`JSON_SCHEMA_SCHEMA_URI\`. The constructor becomes a no-op (retained for callers).

This is safe:
- \`ObjectMapper\` is documented as thread-safe after configuration is complete; the static initializer does all the configuration before any use.
- \`DateTimeFormatter.ofPattern(...)\` returns an immutable, thread-safe formatter.

Helpers reference the constants via \`import static org.metadatacenter.artifacts.model.renderer.JsonArtifactRenderer.MAPPER\` (etc).

### Numbers

- \`JsonArtifactRenderer.java\`: **1985 → 1439 LOC (−27%)**.
- Less dramatic than the Reader's 49% because the orchestration methods (the public entry points plus the instance-artifact rendering helpers and the \`addCore*\`/\`addProvenance\`/\`addVersion\` pieces) coordinate too tightly to extract cleanly.
- 3 new helper files: 278 + 128 + 203 = 609 LOC.

### Behavior

Zero. Methods are byte-for-byte the same; only their location and modifier changed.

### Test plan

- [x] \`mvn clean test\` → 270 tests, 0 failures, 3 pre-existing skips
- [x] \`mvn spotless:check\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)