### PR TITLE
YamlArtifactReader: implement child schemas, value constraints, and default values (PR A)

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReader.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReader.java
@@ -8,7 +8,7 @@ import org.metadatacenter.artifacts.model.core.TemplateInstanceArtifact;
 import org.metadatacenter.artifacts.model.core.TemplateSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.Version;
 import org.metadatacenter.artifacts.model.core.fields.ControlledTermDefaultValue;
-import org.metadatacenter.artifacts.model.core.fields.DefaultValue;
+import org.metadatacenter.artifacts.model.core.fields.LinkDefaultValue;
 import org.metadatacenter.artifacts.model.core.fields.FieldInputType;
 import org.metadatacenter.artifacts.model.core.fields.InputTimeFormat;
 import org.metadatacenter.artifacts.model.core.fields.NumericDefaultValue;
@@ -22,13 +22,16 @@ import org.metadatacenter.artifacts.model.core.fields.constraints.BranchValueCon
 import org.metadatacenter.artifacts.model.core.fields.constraints.ClassValueConstraint;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ControlledTermValueConstraints;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ControlledTermValueConstraintsAction;
+import org.metadatacenter.artifacts.model.core.fields.constraints.LinkValueConstraints;
 import org.metadatacenter.artifacts.model.core.fields.constraints.LiteralValueConstraint;
 import org.metadatacenter.artifacts.model.core.fields.constraints.NumericValueConstraints;
 import org.metadatacenter.artifacts.model.core.fields.constraints.OntologyValueConstraint;
 import org.metadatacenter.artifacts.model.core.fields.constraints.TemporalValueConstraints;
 import org.metadatacenter.artifacts.model.core.fields.constraints.TextValueConstraints;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ValueConstraints;
+import org.metadatacenter.artifacts.model.core.fields.constraints.ValueConstraintsActionType;
 import org.metadatacenter.artifacts.model.core.fields.constraints.ValueSetValueConstraint;
+import org.metadatacenter.artifacts.model.core.fields.constraints.ValueType;
 import org.metadatacenter.artifacts.model.core.ui.ElementUi;
 import org.metadatacenter.artifacts.model.core.ui.FieldUi;
 import org.metadatacenter.artifacts.model.core.ui.NumericFieldUi;
@@ -45,10 +48,60 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ACRONYM;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ACTION;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ACTIONS;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ACTION_TO;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ALT_LABEL;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ATTRIBUTE_VALUE_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.BRANCH;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.DOI_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.EMAIL_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.LINK_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.NIH_GRANT_ID_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ORCID_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.PFAS_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.PHONE_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.PUBMED_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ROR_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.RRID_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.STATIC_IMAGE;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.STATIC_PAGE_BREAK;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.STATIC_RICH_TEXT;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.STATIC_SECTION_BREAK;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.STATIC_YOUTUBE_FIELD;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.CHECKBOX_FIELD;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.CLASS;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.DATATYPE;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.DECIMAL_PLACES;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.DELETE_ACTION;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.FIELD_TYPES;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.IRI;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.LABEL;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.LITERAL;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MAX_DEPTH;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MAX_LENGTH;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MAX_VALUE;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MIN_LENGTH;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MIN_VALUE;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.NUM_TERMS;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ONTOLOGY;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ONTOLOGY_NAME;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.RECOMMENDED;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.REGEX;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.REQUIRED;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.SELECTED_BY_DEFAULT;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.SOURCE_ACRONYM;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.SOURCE_IRI;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.TERM_IRI;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.TERM_LABEL;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.TERM_TYPE;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.UNIT;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.VALUE_SET;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.VALUE_SET_NAME;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.CONTENT;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.CONTINUE_PREVIOUS_LINE;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.CONTROLLED_TERM_FIELD;
@@ -66,8 +119,14 @@ import static org.metadatacenter.artifacts.model.yaml.YamlConstants.HEIGHT;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.HIDDEN;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ID;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.IDENTIFIER;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.CHILDREN;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.CONFIGURATION;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.DEFAULT;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.DEFAULT_LABEL;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.DEFAULT_VALUE;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.INPUT_TIME_FORMAT;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.INPUT_TIME_ZONE;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.KEY;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.LANGUAGE;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MAX_ITEMS;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MIN_ITEMS;
@@ -79,6 +138,8 @@ import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MULTI_SELECT
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.NAME;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.NUMERIC_FIELD;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ORDER;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.OVERRIDE_DESCRIPTION;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.OVERRIDE_LABEL;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.PREF_LABEL;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.PREVIOUS_VERSION;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.PROPERTY_DESCRIPTIONS;
@@ -102,24 +163,6 @@ import static org.metadatacenter.model.ModelNodeNames.FIELD_SCHEMA_ARTIFACT_CONT
 import static org.metadatacenter.model.ModelNodeNames.FIELD_SCHEMA_ARTIFACT_TYPE_IRI;
 import static org.metadatacenter.model.ModelNodeNames.PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
 import static org.metadatacenter.model.ModelNodeNames.TEMPLATE_SCHEMA_ARTIFACT_TYPE_IRI;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_ACTIONS;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_BRANCHES;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_CLASSES;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_DECIMAL_PLACE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_DEFAULT_VALUE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_LITERALS;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_MAX_NUMBER_VALUE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_MAX_STRING_LENGTH;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_MIN_NUMBER_VALUE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_MIN_STRING_LENGTH;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_MULTIPLE_CHOICE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_NUMBER_TYPE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_ONTOLOGIES;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_RECOMMENDED_VALUE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_REQUIRED_VALUE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_TEMPORAL_TYPE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_UNIT_OF_MEASURE;
-import static org.metadatacenter.model.ModelNodeNames.VALUE_CONSTRAINTS_VALUE_SETS;
 import static org.metadatacenter.model.ModelNodeValues.TEMPORAL_GRANULARITIES;
 import static org.metadatacenter.model.ModelNodeValues.TIME_FORMATS;
 
@@ -182,6 +225,7 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
     if (!artifactType.equals(TEMPLATE))
       throw new ArtifactParseException("invalid artifact type " + artifactType + "; should be " + TEMPLATE, TYPE, path);
 
+    checkSchemaArtifactModelVersion(sourceNode, path);
     return readTemplateSchemaArtifact(sourceNode, path);
   }
 
@@ -218,6 +262,7 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
     if (!artifactType.equals(ELEMENT))
       throw new ArtifactParseException("invalid artifact type " + artifactType + "; should be " + ELEMENT, TYPE, path);
 
+    checkSchemaArtifactModelVersion(sourceNode, path);
     return readElementSchemaArtifact(sourceNode, path);
   }
 
@@ -247,6 +292,7 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
   {
     String path = "/";
 
+    checkSchemaArtifactModelVersion(sourceNode, path);
     return readFieldSchemaArtifact(sourceNode, path);
   }
 
@@ -274,13 +320,15 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
     Optional<URI> modifiedBy = readUri(sourceNode, path, MODIFIED_BY);
     Optional<OffsetDateTime> createdOn = readOffsetDatetime(sourceNode, path, CREATED_ON);
     Optional<OffsetDateTime> lastUpdatedOn = readOffsetDatetime(sourceNode, path, MODIFIED_ON);
-    LinkedHashMap<String, ElementSchemaArtifact> elementSchemas = new LinkedHashMap<>(); // TODO Read child elements
-    LinkedHashMap<String, FieldSchemaArtifact> fieldSchemas = new LinkedHashMap<>(); // TODO Read child fields
+    LinkedHashMap<String, ElementSchemaArtifact> elementSchemas = new LinkedHashMap<>();
+    LinkedHashMap<String, FieldSchemaArtifact> fieldSchemas = new LinkedHashMap<>();
+    List<String> childOrder = new ArrayList<>();
+    LinkedHashMap<String, String> childLabels = new LinkedHashMap<>();
+    LinkedHashMap<String, String> childDescriptions = new LinkedHashMap<>();
+    readChildSchemas(sourceNode, path, fieldSchemas, elementSchemas, childOrder, childLabels, childDescriptions);
     Optional<String> language = readString(sourceNode, path, LANGUAGE);
-    TemplateUi templateUi = readTemplateUi(sourceNode, path);
+    TemplateUi templateUi = readTemplateUi(sourceNode, path, childOrder, childLabels, childDescriptions);
     Optional<Annotations> annotations = readAnnotations(sourceNode, path);
-
-    checkSchemaArtifactModelVersion(sourceNode, path);
 
     return TemplateSchemaArtifact.create(jsonLdContext, jsonLdTypes, jsonLdId, instanceJsonLdType, templateName,
       description, identifier, version, status, previousVersion, derivedFrom, createdBy, modifiedBy, createdOn,
@@ -307,19 +355,25 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
     Optional<URI> modifiedBy = readUri(sourceNode, path, MODIFIED_BY);
     Optional<OffsetDateTime> createdOn = readOffsetDatetime(sourceNode, path, CREATED_ON);
     Optional<OffsetDateTime> lastUpdatedOn = readOffsetDatetime(sourceNode, path, MODIFIED_ON);
-    LinkedHashMap<String, ElementSchemaArtifact> elementSchemas = new LinkedHashMap<>(); // TODO  Read child elements
-    LinkedHashMap<String, FieldSchemaArtifact> fieldSchemas = new LinkedHashMap<>(); // TODO  Read child fields
+    LinkedHashMap<String, ElementSchemaArtifact> elementSchemas = new LinkedHashMap<>();
+    LinkedHashMap<String, FieldSchemaArtifact> fieldSchemas = new LinkedHashMap<>();
+    List<String> childOrder = new ArrayList<>();
+    LinkedHashMap<String, String> childLabels = new LinkedHashMap<>();
+    LinkedHashMap<String, String> childDescriptions = new LinkedHashMap<>();
+    readChildSchemas(sourceNode, path, fieldSchemas, elementSchemas, childOrder, childLabels, childDescriptions);
     Optional<String> language = readString(sourceNode, path, LANGUAGE);
-    ElementUi elementUi = readElementUi(sourceNode, path);
+    ElementUi elementUi = readElementUi(sourceNode, path, childOrder, childLabels, childDescriptions);
     Optional<Annotations> annotations = readAnnotations(sourceNode, path);
 
-    checkSchemaArtifactModelVersion(sourceNode, path);
-
-    // TODO These are in CONFIGURATIONS
-    boolean isMultiple = readBoolean(sourceNode, path, MULTIPLE, false);
-    Optional<Integer> minItems = readInteger(sourceNode, path, MIN_ITEMS);
-    Optional<Integer> maxItems = readInteger(sourceNode, path, MAX_ITEMS);
-    Optional<URI> propertyUri = readUri(sourceNode, path, PROPERTY_IRI);
+    // isMultiple / minItems / maxItems / propertyUri are written by the renderer under the
+    // `configuration:` sub-block for nested elements. Accept either location for
+    // backwards-compat with hand-authored YAML and the existing reader tests.
+    LinkedHashMap<String, Object> configNode = readChildNode(sourceNode, path, CONFIGURATION);
+    LinkedHashMap<String, Object> configSource = configNode != null ? configNode : sourceNode;
+    boolean isMultiple = readBoolean(configSource, path, MULTIPLE, false);
+    Optional<Integer> minItems = readInteger(configSource, path, MIN_ITEMS);
+    Optional<Integer> maxItems = readInteger(configSource, path, MAX_ITEMS);
+    Optional<URI> propertyUri = readUri(configSource, path, PROPERTY_IRI);
 
     return ElementSchemaArtifact.create(internalName, internalDescription, jsonLdContext, jsonLdTypes, jsonLdId,
       instanceJsonLdType, elementName, description, identifier, version, status, previousVersion, derivedFrom,
@@ -347,19 +401,20 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
     Optional<OffsetDateTime> lastUpdatedOn = readOffsetDatetime(sourceNode, path, MODIFIED_ON);
     FieldInputType fieldInputType = readFieldInputType(sourceNode, path, TYPE);
     FieldUi fieldUi = readFieldUi(sourceNode, path, fieldInputType);
-    Optional<ValueConstraints> valueConstraints = readValueConstraints(sourceNode, path, VALUES, fieldUi.inputType());
+    LinkedHashMap<String, Object> configNode = readChildNode(sourceNode, path, CONFIGURATION);
+    Optional<ValueConstraints> valueConstraints = readValueConstraints(sourceNode, path, fieldInputType, configNode);
     Optional<String> preferredLabel = readString(sourceNode, path, PREF_LABEL);
     List<String> alternateLabels = readStringArray(sourceNode, path, ALT_LABEL);
     Optional<String> language = readString(sourceNode, path, LANGUAGE);
     Optional<Annotations> annotations = readAnnotations(sourceNode, path);
 
-    // TODO These are in CONFIGURATIONS
-    boolean isMultiple = readBoolean(sourceNode, path, MULTIPLE, false);
-    Optional<Integer> minItems = readInteger(sourceNode, path, MIN_ITEMS);
-    Optional<Integer> maxItems = readInteger(sourceNode, path, MAX_ITEMS);
-    Optional<URI> propertyUri = readUri(sourceNode, path, PROPERTY_IRI);
-
-    checkSchemaArtifactModelVersion(sourceNode, path);
+    // isMultiple / minItems / maxItems / propertyUri live under the `configuration:` sub-block
+    // for nested fields; top-level fields rendered by the renderer don't write configuration.
+    LinkedHashMap<String, Object> configSource = configNode != null ? configNode : new LinkedHashMap<>();
+    boolean isMultiple = readBoolean(configSource, path, MULTIPLE, false);
+    Optional<Integer> minItems = readInteger(configSource, path, MIN_ITEMS);
+    Optional<Integer> maxItems = readInteger(configSource, path, MAX_ITEMS);
+    Optional<URI> propertyUri = readUri(configSource, path, PROPERTY_IRI);
 
     return FieldSchemaArtifact.create(internalName, internalDescription, jsonLdContext, jsonLdTypes, jsonLdId,
       fieldName, description, identifier, version, status, previousVersion, derivedFrom, isMultiple, minItems, maxItems,
@@ -367,22 +422,35 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
       valueConstraints, annotations);
   }
 
-  private TemplateUi readTemplateUi(LinkedHashMap<String, Object> sourceNode, String path)
+  private TemplateUi readTemplateUi(LinkedHashMap<String, Object> sourceNode, String path,
+    List<String> derivedOrder, LinkedHashMap<String, String> derivedLabels,
+    LinkedHashMap<String, String> derivedDescriptions)
   {
-    List<String> order = readStringArray(sourceNode, path, ORDER);
+    // The renderer derives order/labels/descriptions from the children list and never writes them
+    // as separate top-level keys; we accept the explicit keys for backwards-compat with hand-
+    // authored YAML and fall back to the derived ones.
+    List<String> explicitOrder = readStringArray(sourceNode, path, ORDER);
+    List<String> order = explicitOrder.isEmpty() ? derivedOrder : explicitOrder;
     LinkedHashMap<String, String> propertyLabels = readString2StringMap(sourceNode, path, PROPERTY_LABELS);
+    if (propertyLabels.isEmpty()) propertyLabels = derivedLabels;
     LinkedHashMap<String, String> propertyDescriptions = readString2StringMap(sourceNode, path, PROPERTY_DESCRIPTIONS);
+    if (propertyDescriptions.isEmpty()) propertyDescriptions = derivedDescriptions;
     Optional<String> header = readString(sourceNode, path, HEADER);
     Optional<String> footer = readString(sourceNode, path, FOOTER);
 
     return TemplateUi.create(order, propertyLabels, propertyDescriptions, header, footer);
   }
 
-  private ElementUi readElementUi(LinkedHashMap<String, Object> sourceNode, String path)
+  private ElementUi readElementUi(LinkedHashMap<String, Object> sourceNode, String path,
+    List<String> derivedOrder, LinkedHashMap<String, String> derivedLabels,
+    LinkedHashMap<String, String> derivedDescriptions)
   {
-    List<String> order = readStringArray(sourceNode, path, ORDER);
+    List<String> explicitOrder = readStringArray(sourceNode, path, ORDER);
+    List<String> order = explicitOrder.isEmpty() ? derivedOrder : explicitOrder;
     LinkedHashMap<String, String> propertyLabels = readString2StringMap(sourceNode, path, PROPERTY_LABELS);
+    if (propertyLabels.isEmpty()) propertyLabels = derivedLabels;
     LinkedHashMap<String, String> propertyDescriptions = readString2StringMap(sourceNode, path, PROPERTY_DESCRIPTIONS);
+    if (propertyDescriptions.isEmpty()) propertyDescriptions = derivedDescriptions;
 
     return ElementUi.create(order, propertyLabels, propertyDescriptions);
   }
@@ -417,69 +485,64 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
     }
   }
 
+  /**
+   * Read value constraints for a field. Unlike the JSON-Schema serialization (which nests
+   * constraints under a {@code _valueConstraints} object), the YAML renderer inlines them at the
+   * field level: {@code minLength}, {@code maxLength}, {@code regex}, {@code default},
+   * {@code datatype}, {@code minValue}, {@code maxValue}, {@code decimalPlaces}, {@code unit},
+   * plus a {@code values:} list for controlled-term / literal constraints and an {@code actions:}
+   * list. {@code required}, {@code recommended}, and {@code multipleChoice} come from the
+   * {@code configuration:} sub-block (when this field is a child of a template or element).
+   */
   private Optional<ValueConstraints> readValueConstraints(LinkedHashMap<String, Object> sourceNode, String path,
-    String fieldKey, FieldInputType fieldInputType)
+    FieldInputType fieldInputType, LinkedHashMap<String, Object> configNode)
   {
-    String vcPath = path + "/" + fieldKey;
-    LinkedHashMap<String, Object> vcNode = readChildNode(sourceNode, path, fieldKey);
+    boolean requiredValue = configNode != null && readBoolean(configNode, path, REQUIRED, false);
+    boolean recommendedValue = configNode != null && readBoolean(configNode, path, RECOMMENDED, false);
+    // Checkbox is inherently multi-select; the renderer also encodes multi-select list by the
+    // multi-select-list-field discriminator (which we map to FieldInputType.LIST). We don't have
+    // the original discriminator here, so we conservatively flag multi for checkbox only.
+    boolean multipleChoice = fieldInputType == FieldInputType.CHECKBOX;
 
-    if (vcNode != null) {
-      boolean requiredValue = readBoolean(vcNode, vcPath, VALUE_CONSTRAINTS_REQUIRED_VALUE, false);
-      boolean recommendedValue = readBoolean(vcNode, vcPath, VALUE_CONSTRAINTS_RECOMMENDED_VALUE, false);
-      boolean multipleChoice = readBoolean(vcNode, vcPath, VALUE_CONSTRAINTS_MULTIPLE_CHOICE, false);
-      Optional<XsdNumericDatatype> numberType = readNumberType(vcNode, vcPath, VALUE_CONSTRAINTS_NUMBER_TYPE);
-      Optional<XsdTemporalDatatype> temporalType = readTemporalType(vcNode, vcPath, VALUE_CONSTRAINTS_TEMPORAL_TYPE);
-      Optional<String> unitOfMeasure = readString(vcNode, vcPath, VALUE_CONSTRAINTS_UNIT_OF_MEASURE);
-      Optional<Number> minValue = readNumber(vcNode, vcPath, VALUE_CONSTRAINTS_MIN_NUMBER_VALUE);
-      Optional<Number> maxValue = readNumber(vcNode, vcPath, VALUE_CONSTRAINTS_MAX_NUMBER_VALUE);
-      Optional<Integer> decimalPlaces = readInteger(vcNode, vcPath, VALUE_CONSTRAINTS_DECIMAL_PLACE);
-      Optional<Integer> minLength = readInteger(vcNode, vcPath, VALUE_CONSTRAINTS_MIN_STRING_LENGTH);
-      Optional<Integer> maxLength = readInteger(vcNode, vcPath, VALUE_CONSTRAINTS_MAX_STRING_LENGTH);
-      Optional<? extends DefaultValue> defaultValue = readDefaultValue(vcNode, vcPath, VALUE_CONSTRAINTS_DEFAULT_VALUE);
-      Optional<String> regex = readString(vcNode, vcPath, "regex"); // TODO Add 'regex' to ModelNodeNames
-      List<OntologyValueConstraint> ontologies = readOntologyValueConstraints(vcNode, vcPath,
-        VALUE_CONSTRAINTS_ONTOLOGIES);
-      List<ValueSetValueConstraint> valueSets = readValueSetValueConstraints(vcNode, vcPath,
-        VALUE_CONSTRAINTS_VALUE_SETS);
-      List<ClassValueConstraint> classes = readClassValueConstraints(vcNode, vcPath, VALUE_CONSTRAINTS_CLASSES);
-      List<BranchValueConstraint> branches = readBranchValueConstraints(vcNode, vcPath, VALUE_CONSTRAINTS_BRANCHES);
-      List<LiteralValueConstraint> literals = readLiteralValueConstraints(vcNode, vcPath, VALUE_CONSTRAINTS_LITERALS);
-      List<ControlledTermValueConstraintsAction> actions = readValueConstraintsActions(vcNode, vcPath,
-        VALUE_CONSTRAINTS_ACTIONS);
+    Optional<String> unitOfMeasure = readString(sourceNode, path, UNIT);
+    Optional<Number> minValue = readNumber(sourceNode, path, MIN_VALUE);
+    Optional<Number> maxValue = readNumber(sourceNode, path, MAX_VALUE);
+    Optional<Integer> decimalPlaces = readInteger(sourceNode, path, DECIMAL_PLACES);
+    Optional<Integer> minLength = readInteger(sourceNode, path, MIN_LENGTH);
+    Optional<Integer> maxLength = readInteger(sourceNode, path, MAX_LENGTH);
+    Optional<String> regex = readString(sourceNode, path, REGEX);
 
-      if (fieldInputType == FieldInputType.NUMERIC) {
-        Optional<NumericDefaultValue> numericDefaultValue = defaultValue.isPresent() ?
-          Optional.of(defaultValue.get().asNumericDefaultValue()) :
-          Optional.empty();
-        return Optional.of(
-          NumericValueConstraints.create(numberType.get(), minValue, maxValue, decimalPlaces, unitOfMeasure,
-            numericDefaultValue, requiredValue, recommendedValue, multipleChoice));
-      } else if (fieldInputType == FieldInputType.TEMPORAL) {
-        Optional<TemporalDefaultValue> temporalDefaultValue = defaultValue.isPresent() ?
-          Optional.of(defaultValue.get().asTemporalDefaultValue()) :
-          Optional.empty();
-        return Optional.of(
-          TemporalValueConstraints.create(temporalType.get(), temporalDefaultValue, requiredValue, recommendedValue,
-            multipleChoice));
+    List<OntologyValueConstraint> ontologies = readOntologyValueConstraints(sourceNode, path);
+    List<ValueSetValueConstraint> valueSets = readValueSetValueConstraints(sourceNode, path);
+    List<ClassValueConstraint> classes = readClassValueConstraints(sourceNode, path);
+    List<BranchValueConstraint> branches = readBranchValueConstraints(sourceNode, path);
+    List<LiteralValueConstraint> literals = readLiteralValueConstraints(sourceNode, path);
+    List<ControlledTermValueConstraintsAction> actions = readValueConstraintsActions(sourceNode, path);
 
-      } else if (fieldInputType == FieldInputType.LINK || (fieldInputType == FieldInputType.TEXTFIELD && (
-        !ontologies.isEmpty() || !valueSets.isEmpty() || !classes.isEmpty() || !branches.isEmpty()))) {
-        Optional<ControlledTermDefaultValue> controlledTermDefaultValue = defaultValue.isPresent() ?
-          Optional.of(defaultValue.get().asControlledTermDefaultValue()) :
-          Optional.empty();
-        return Optional.of(
-          ControlledTermValueConstraints.create(ontologies, valueSets, classes, branches, controlledTermDefaultValue,
-            actions, requiredValue, recommendedValue, multipleChoice));
-      } else {
-        Optional<TextDefaultValue> textDefaultValue = defaultValue.isPresent() ?
-          Optional.of(defaultValue.get().asTextDefaultValue()) :
-          Optional.empty();
-        return Optional.of(
-          TextValueConstraints.create(minLength, maxLength, textDefaultValue, literals, requiredValue, recommendedValue,
-            multipleChoice, regex));
-      }
+    if (fieldInputType == FieldInputType.NUMERIC) {
+      Optional<XsdNumericDatatype> numberType = readNumberType(sourceNode, path, DATATYPE);
+      Optional<NumericDefaultValue> numericDefaultValue = readNumericDefaultValue(sourceNode, path);
+      return Optional.of(NumericValueConstraints.create(numberType.orElse(XsdNumericDatatype.DECIMAL), minValue,
+        maxValue, decimalPlaces, unitOfMeasure, numericDefaultValue, requiredValue, recommendedValue, multipleChoice));
+    } else if (fieldInputType == FieldInputType.TEMPORAL) {
+      Optional<XsdTemporalDatatype> temporalType = readTemporalType(sourceNode, path, DATATYPE);
+      Optional<TemporalDefaultValue> temporalDefaultValue = readTemporalDefaultValue(sourceNode, path);
+      return Optional.of(TemporalValueConstraints.create(temporalType.orElse(XsdTemporalDatatype.DATETIME),
+        temporalDefaultValue, requiredValue, recommendedValue, multipleChoice));
+    } else if (fieldInputType == FieldInputType.LINK) {
+      Optional<LinkDefaultValue> linkDefaultValue = readLinkDefaultValue(sourceNode, path);
+      return Optional.of(
+        LinkValueConstraints.create(linkDefaultValue, requiredValue, recommendedValue, multipleChoice));
+    } else if (fieldInputType == FieldInputType.TEXTFIELD && (
+      !ontologies.isEmpty() || !valueSets.isEmpty() || !classes.isEmpty() || !branches.isEmpty())) {
+      Optional<ControlledTermDefaultValue> controlledTermDefaultValue = readControlledTermDefaultValue(sourceNode, path);
+      return Optional.of(
+        ControlledTermValueConstraints.create(ontologies, valueSets, classes, branches, controlledTermDefaultValue,
+          actions, requiredValue, recommendedValue, multipleChoice));
     } else {
-      return Optional.empty();
+      Optional<TextDefaultValue> textDefaultValue = readTextDefaultValue(sourceNode, path);
+      return Optional.of(TextValueConstraints.create(minLength, maxLength, textDefaultValue, literals, requiredValue,
+        recommendedValue, multipleChoice, regex));
     }
   }
 
@@ -635,10 +698,12 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
   private TemporalGranularity readTemporalGranularity(LinkedHashMap<String, Object> sourceNode, String path,
     String fieldKey)
   {
-    String granularityString = readRequiredString(sourceNode, path, fieldKey, false);
+    String granularityString = readEnumOrString(sourceNode, path, fieldKey)
+      .orElseThrow(() -> new ArtifactParseException("No field present", fieldKey, path));
 
     if (!TEMPORAL_GRANULARITIES.contains(granularityString))
-      throw new ArtifactParseException("Invalid granularity" + granularityString + " in field " + fieldKey, TYPE, path);
+      throw new ArtifactParseException("Invalid granularity " + granularityString + " in field " + fieldKey, TYPE,
+        path);
 
     return TemporalGranularity.fromString(granularityString);
   }
@@ -646,7 +711,7 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
   private Optional<InputTimeFormat> readInputTimeFormat(LinkedHashMap<String, Object> sourceNode, String path,
     String fieldKey)
   {
-    Optional<String> inputTimeFormatString = readString(sourceNode, path, fieldKey);
+    Optional<String> inputTimeFormatString = readEnumOrString(sourceNode, path, fieldKey);
 
     if (inputTimeFormatString.isEmpty()) {
       return Optional.empty();
@@ -654,7 +719,7 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
 
     if (!TIME_FORMATS.contains(inputTimeFormatString.get()))
       throw new ArtifactParseException(
-        "Invalid input time format" + inputTimeFormatString.get() + " in field" + fieldKey, TYPE, path);
+        "Invalid input time format " + inputTimeFormatString.get() + " in field " + fieldKey, TYPE, path);
 
     return Optional.of(InputTimeFormat.fromString(inputTimeFormatString.get()));
   }
@@ -672,24 +737,31 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
 //      PHONE_FIELD, EMAIL_FIELD, LINK_FIELD, ATTRIBUTE_VALUE_FIELD, STATIC_PAGE_BREAK, STATIC_SECTION_BREAK, STATIC_IMAGE,
 //      STATIC_RICH_TEXT, STATIC_YOUTUBE_FIELD);
 
-    if (inputTypeString.equals(TEXT_FIELD))
-      return FieldInputType.TEXTFIELD;
-    else if (inputTypeString.equals(CONTROLLED_TERM_FIELD))
-      return FieldInputType.TEXTFIELD;
-    else if (inputTypeString.equals(TEXT_AREA_FIELD))
-      return FieldInputType.TEXTAREA;
-    else if (inputTypeString.equals(NUMERIC_FIELD))
-      return FieldInputType.NUMERIC;
-    else if (inputTypeString.equals(TEMPORAL_FIELD))
-      return FieldInputType.TEMPORAL;
-    else if (inputTypeString.equals(RADIO_FIELD))
-      return FieldInputType.RADIO;
-    else if (inputTypeString.equals(CHECKBOX_FIELD))
-      return FieldInputType.CHECKBOX;
-    else if (inputTypeString.equals(SINGLE_SELECT_LIST_FIELD))
-      return FieldInputType.CHECKBOX;
-    else if (inputTypeString.equals(MULTI_SELECT_LIST_FIELD))
-      return FieldInputType.CHECKBOX;
+    if (inputTypeString.equals(TEXT_FIELD)) return FieldInputType.TEXTFIELD;
+    if (inputTypeString.equals(CONTROLLED_TERM_FIELD)) return FieldInputType.TEXTFIELD;
+    if (inputTypeString.equals(TEXT_AREA_FIELD)) return FieldInputType.TEXTAREA;
+    if (inputTypeString.equals(NUMERIC_FIELD)) return FieldInputType.NUMERIC;
+    if (inputTypeString.equals(TEMPORAL_FIELD)) return FieldInputType.TEMPORAL;
+    if (inputTypeString.equals(RADIO_FIELD)) return FieldInputType.RADIO;
+    if (inputTypeString.equals(CHECKBOX_FIELD)) return FieldInputType.CHECKBOX;
+    if (inputTypeString.equals(SINGLE_SELECT_LIST_FIELD)) return FieldInputType.LIST;
+    if (inputTypeString.equals(MULTI_SELECT_LIST_FIELD)) return FieldInputType.LIST;
+    if (inputTypeString.equals(PHONE_FIELD)) return FieldInputType.PHONE_NUMBER;
+    if (inputTypeString.equals(EMAIL_FIELD)) return FieldInputType.EMAIL;
+    if (inputTypeString.equals(LINK_FIELD)) return FieldInputType.LINK;
+    if (inputTypeString.equals(ROR_FIELD)) return FieldInputType.ROR;
+    if (inputTypeString.equals(ORCID_FIELD)) return FieldInputType.ORCID;
+    if (inputTypeString.equals(PFAS_FIELD)) return FieldInputType.PFAS;
+    if (inputTypeString.equals(RRID_FIELD)) return FieldInputType.RRID;
+    if (inputTypeString.equals(PUBMED_FIELD)) return FieldInputType.PUBMED;
+    if (inputTypeString.equals(NIH_GRANT_ID_FIELD)) return FieldInputType.NIH_GRANT_ID;
+    if (inputTypeString.equals(DOI_FIELD)) return FieldInputType.DOI;
+    if (inputTypeString.equals(ATTRIBUTE_VALUE_FIELD)) return FieldInputType.ATTRIBUTE_VALUE;
+    if (inputTypeString.equals(STATIC_PAGE_BREAK)) return FieldInputType.PAGE_BREAK;
+    if (inputTypeString.equals(STATIC_SECTION_BREAK)) return FieldInputType.SECTION_BREAK;
+    if (inputTypeString.equals(STATIC_RICH_TEXT)) return FieldInputType.RICHTEXT;
+    if (inputTypeString.equals(STATIC_IMAGE)) return FieldInputType.IMAGE;
+    if (inputTypeString.equals(STATIC_YOUTUBE_FIELD)) return FieldInputType.YOUTUBE;
 
     return FieldInputType.fromString(inputTypeString);
   }
@@ -719,28 +791,39 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
       throw new ArtifactParseException("Invalid version " + versionString, fieldKey, path);
   }
 
+  /**
+   * Read a value that may be either a {@link String} or an enum/object that resolves to a string
+   * via {@link Object#toString()}. The renderer leaves some values (e.g. datatype enums) as enum
+   * instances rather than strings in the in-memory map; YAML serialization later turns them into
+   * strings. For an in-memory round-trip we need to accept both forms.
+   */
+  private Optional<String> readEnumOrString(LinkedHashMap<String, Object> sourceNode, String path, String fieldKey)
+  {
+    if (!sourceNode.containsKey(fieldKey)) return Optional.empty();
+    Object raw = sourceNode.get(fieldKey);
+    if (raw == null) return Optional.empty();
+    // Unwrap Optional<...> — the renderer occasionally puts an Optional in the map
+    // (e.g. for inputTimeFormat) rather than its inner value.
+    if (raw instanceof Optional<?>) {
+      Optional<?> opt = (Optional<?>) raw;
+      if (opt.isEmpty()) return Optional.empty();
+      raw = opt.get();
+    }
+    if (raw instanceof String) return Optional.of((String) raw);
+    if (raw instanceof Enum<?>) return Optional.of(raw.toString());
+    throw new ArtifactParseException("Expecting string or enum value, got " + raw.getClass(), fieldKey, path);
+  }
+
   private Optional<XsdNumericDatatype> readNumberType(LinkedHashMap<String, Object> sourceNode, String path,
     String fieldKey)
   {
-    Optional<String> numberTypeValue = readString(sourceNode, path, fieldKey);
-
-    if (numberTypeValue.isPresent()) {
-      return Optional.of(XsdNumericDatatype.fromString(numberTypeValue.get()));
-    } else {
-      return Optional.empty();
-    }
+    return readEnumOrString(sourceNode, path, fieldKey).map(XsdNumericDatatype::fromString);
   }
 
   private Optional<XsdTemporalDatatype> readTemporalType(LinkedHashMap<String, Object> sourceNode, String path,
     String fieldKey)
   {
-    Optional<String> temporalTypeValue = readString(sourceNode, path, fieldKey);
-
-    if (temporalTypeValue.isPresent()) {
-      return Optional.of(XsdTemporalDatatype.fromString(temporalTypeValue.get()));
-    } else {
-      return Optional.empty();
-    }
+    return readEnumOrString(sourceNode, path, fieldKey).map(XsdTemporalDatatype::fromString);
   }
 
   private Status readRequiredStatus(LinkedHashMap<String, Object> sourceNode, String path, String fieldKey)
@@ -842,58 +925,259 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
     }
   }
 
-  private Optional<DefaultValue> readDefaultValue(LinkedHashMap<String, Object> sourceNode, String path,
-    String fieldKey)
+  /**
+   * Read each entry of the {@code values:} list at {@code sourceNode}, dispatching to the supplied
+   * mapper for entries whose {@code type} discriminator matches {@code typeDiscriminator}. Entries
+   * that don't match (e.g. {@code literal:}-style entries when reading ontology constraints) are
+   * silently skipped.
+   */
+  @SuppressWarnings("unchecked")
+  private <T> List<T> readValuesEntriesOfType(LinkedHashMap<String, Object> sourceNode, String path,
+    String typeDiscriminator, java.util.function.Function<LinkedHashMap<String, Object>, T> mapper)
   {
-    return Optional.empty(); // TODO Implement read default value
+    Object raw = sourceNode.get(VALUES);
+    if (!(raw instanceof List<?>))
+      return Collections.emptyList();
+    List<T> result = new ArrayList<>();
+    for (Object rawEntry : (List<?>) raw) {
+      if (!(rawEntry instanceof LinkedHashMap<?, ?>)) continue;
+      LinkedHashMap<String, Object> entry = (LinkedHashMap<String, Object>) rawEntry;
+      Object t = entry.get(TYPE);
+      if (typeDiscriminator.equals(t))
+        result.add(mapper.apply(entry));
+    }
+    return result;
   }
 
   private List<OntologyValueConstraint> readOntologyValueConstraints(LinkedHashMap<String, Object> sourceNode,
-    String path, String fieldKey)
+    String path)
   {
-    return Collections.emptyList(); // TODO Implement read ontology value constraints
+    return readValuesEntriesOfType(sourceNode, path, ONTOLOGY, entry -> {
+      String acronym = readRequiredString(entry, path, ACRONYM, false);
+      String name = readRequiredString(entry, path, ONTOLOGY_NAME, false);
+      URI iri = readRequiredUri(entry, path, IRI);
+      Optional<Integer> numTerms = readInteger(entry, path, NUM_TERMS);
+      return new OntologyValueConstraint(iri, acronym, name, numTerms);
+    });
   }
 
-  private List<ClassValueConstraint> readClassValueConstraints(LinkedHashMap<String, Object> sourceNode, String path,
-    String fieldKey)
+  private List<ClassValueConstraint> readClassValueConstraints(LinkedHashMap<String, Object> sourceNode, String path)
   {
-    return Collections.emptyList(); // TODO Implement read class value constraints
+    return readValuesEntriesOfType(sourceNode, path, CLASS, entry -> {
+      String label = readRequiredString(entry, path, LABEL, false);
+      String acronym = readRequiredString(entry, path, ACRONYM, false);
+      String termType = readRequiredString(entry, path, TERM_TYPE, false);
+      String termLabel = readRequiredString(entry, path, TERM_LABEL, false);
+      URI iri = readRequiredUri(entry, path, IRI);
+      ValueType valueType = termType.equalsIgnoreCase(CLASS)
+        ? ValueType.ONTOLOGY_CLASS
+        : ValueType.VALUE;
+      return new ClassValueConstraint(iri, acronym, label, termLabel, valueType);
+    });
   }
 
   private List<ValueSetValueConstraint> readValueSetValueConstraints(LinkedHashMap<String, Object> sourceNode,
-    String path, String fieldKey)
+    String path)
   {
-    return Collections.emptyList(); // TODO Implement read value set value constraints
+    return readValuesEntriesOfType(sourceNode, path, VALUE_SET, entry -> {
+      String acronym = readRequiredString(entry, path, ACRONYM, false);
+      String name = readRequiredString(entry, path, VALUE_SET_NAME, false);
+      URI iri = readRequiredUri(entry, path, IRI);
+      Optional<Integer> numTerms = readInteger(entry, path, NUM_TERMS);
+      return new ValueSetValueConstraint(iri, acronym, name, numTerms);
+    });
   }
 
-  private List<BranchValueConstraint> readBranchValueConstraints(LinkedHashMap<String, Object> sourceNode, String path,
-    String fieldKey)
+  private List<BranchValueConstraint> readBranchValueConstraints(LinkedHashMap<String, Object> sourceNode, String path)
   {
-    return Collections.emptyList(); // TODO Implement read branch value constraints
+    return readValuesEntriesOfType(sourceNode, path, BRANCH, entry -> {
+      String ontologyName = readRequiredString(entry, path, ONTOLOGY_NAME, false);
+      String acronym = readRequiredString(entry, path, ACRONYM, false);
+      String termLabel = readRequiredString(entry, path, TERM_LABEL, false);
+      URI iri = readRequiredUri(entry, path, IRI);
+      Optional<Integer> maxDepth = readInteger(entry, path, MAX_DEPTH);
+      return new BranchValueConstraint(iri, ontologyName, acronym, termLabel, maxDepth.orElse(0));
+    });
   }
 
+  /**
+   * Literal entries don't have a {@code type:} discriminator; they're distinguished by carrying
+   * a {@code literal:} key.
+   */
+  @SuppressWarnings("unchecked")
   private List<LiteralValueConstraint> readLiteralValueConstraints(LinkedHashMap<String, Object> sourceNode,
-    String path, String fieldKey)
+    String path)
   {
-    return Collections.emptyList(); // TODO Implement read literal value constraints
+    Object raw = sourceNode.get(VALUES);
+    if (!(raw instanceof List<?>))
+      return Collections.emptyList();
+    List<LiteralValueConstraint> result = new ArrayList<>();
+    for (Object rawEntry : (List<?>) raw) {
+      if (!(rawEntry instanceof LinkedHashMap<?, ?>)) continue;
+      LinkedHashMap<String, Object> entry = (LinkedHashMap<String, Object>) rawEntry;
+      if (entry.containsKey(LITERAL)) {
+        String label = readRequiredString(entry, path, LITERAL, false);
+        boolean selected = readBoolean(entry, path, SELECTED_BY_DEFAULT, false);
+        result.add(new LiteralValueConstraint(label, selected));
+      }
+    }
+    return result;
   }
 
+  @SuppressWarnings("unchecked")
   private List<ControlledTermValueConstraintsAction> readValueConstraintsActions(
-    LinkedHashMap<String, Object> sourceNode, String path, String fieldKey)
+    LinkedHashMap<String, Object> sourceNode, String path)
   {
-    return Collections.emptyList(); // TODO Implement read actions value constraints
+    Object raw = sourceNode.get(ACTIONS);
+    if (!(raw instanceof List<?>))
+      return Collections.emptyList();
+    List<ControlledTermValueConstraintsAction> result = new ArrayList<>();
+    for (Object rawEntry : (List<?>) raw) {
+      if (!(rawEntry instanceof LinkedHashMap<?, ?>)) continue;
+      LinkedHashMap<String, Object> entry = (LinkedHashMap<String, Object>) rawEntry;
+
+      String actionName = readRequiredString(entry, path, ACTION, false);
+      ValueConstraintsActionType actionType = actionName.equalsIgnoreCase(DELETE_ACTION)
+        ? ValueConstraintsActionType.DELETE
+        : ValueConstraintsActionType.MOVE;
+      Optional<Integer> to = readInteger(entry, path, ACTION_TO);
+      URI termIri = readRequiredUri(entry, path, TERM_IRI);
+      Optional<URI> sourceIri = readUri(entry, path, SOURCE_IRI);
+      String sourceAcronym = readRequiredString(entry, path, SOURCE_ACRONYM, false);
+      String typeName = readRequiredString(entry, path, TYPE, false);
+      ValueType valueType = typeName.equalsIgnoreCase(CLASS) ? ValueType.ONTOLOGY_CLASS : ValueType.VALUE;
+
+      result.add(new ControlledTermValueConstraintsAction(termIri, sourceAcronym, valueType, actionType, sourceIri, to));
+    }
+    return result;
+  }
+
+  private Optional<TextDefaultValue> readTextDefaultValue(LinkedHashMap<String, Object> sourceNode, String path)
+  {
+    Optional<String> raw = readString(sourceNode, path, DEFAULT);
+    return raw.map(TextDefaultValue::new);
+  }
+
+  private Optional<NumericDefaultValue> readNumericDefaultValue(LinkedHashMap<String, Object> sourceNode, String path)
+  {
+    Optional<Number> raw = readNumber(sourceNode, path, DEFAULT);
+    return raw.map(NumericDefaultValue::new);
+  }
+
+  private Optional<LinkDefaultValue> readLinkDefaultValue(LinkedHashMap<String, Object> sourceNode, String path)
+  {
+    return readUri(sourceNode, path, DEFAULT).map(LinkDefaultValue::new);
+  }
+
+  private Optional<TemporalDefaultValue> readTemporalDefaultValue(LinkedHashMap<String, Object> sourceNode, String path)
+  {
+    Optional<String> raw = readString(sourceNode, path, DEFAULT);
+    return raw.map(TemporalDefaultValue::new);
+  }
+
+  /**
+   * The controlled-term default is a map with {@code value:} (an IRI) and {@code label:} keys.
+   */
+  private Optional<ControlledTermDefaultValue> readControlledTermDefaultValue(
+    LinkedHashMap<String, Object> sourceNode, String path)
+  {
+    LinkedHashMap<String, Object> defaultNode = readChildNode(sourceNode, path, DEFAULT);
+    if (defaultNode == null)
+      return Optional.empty();
+    URI uri = readRequiredUri(defaultNode, path, DEFAULT_VALUE);
+    String label = readRequiredString(defaultNode, path, DEFAULT_LABEL, false);
+    return Optional.of(new ControlledTermDefaultValue(uri, label));
   }
 
   private LinkedHashMap<String, String> readString2StringMap(LinkedHashMap<String, Object> sourceNode, String path,
     String fieldKey)
   {
-    return new LinkedHashMap<>(); // TODO Implement readString2StringMap
+    LinkedHashMap<String, Object> raw = readChildNode(sourceNode, path, fieldKey);
+    if (raw == null)
+      return new LinkedHashMap<>();
+
+    LinkedHashMap<String, String> result = new LinkedHashMap<>();
+    for (Map.Entry<String, Object> entry : raw.entrySet()) {
+      if (entry.getValue() instanceof String)
+        result.put(entry.getKey(), (String) entry.getValue());
+      else
+        throw new ArtifactParseException("Expected string value at key " + entry.getKey(), fieldKey, path);
+    }
+    return result;
   }
 
+  /**
+   * Returns the child map at {@code parentNode[fieldKey]} or {@code null} if the field is absent
+   * or {@code null}-valued.
+   */
+  @SuppressWarnings("unchecked")
   private LinkedHashMap<String, Object> readChildNode(LinkedHashMap<String, Object> parentNode, String path,
     String fieldKey)
   {
-    return new LinkedHashMap<>(); // TODO Implement read child node
+    Object raw = parentNode.get(fieldKey);
+    if (raw == null)
+      return null;
+    if (!(raw instanceof LinkedHashMap<?, ?>))
+      throw new ArtifactParseException("Expected map value, got " + raw.getClass(), fieldKey, path);
+    return (LinkedHashMap<String, Object>) raw;
+  }
+
+  /**
+   * Walk a YAML list under {@code fieldKey}, dispatching each entry to the appropriate reader
+   * (field vs element) by its {@code type} discriminator. Populates the supplied maps with the
+   * parsed children, builds the {@code order} list in document order, and builds
+   * {@code propertyLabels} / {@code propertyDescriptions} from each child's name/description
+   * (mirroring what the builder does when assembling templates/elements in code).
+   */
+  @SuppressWarnings("unchecked")
+  private void readChildSchemas(LinkedHashMap<String, Object> sourceNode, String path,
+    LinkedHashMap<String, FieldSchemaArtifact> fieldSchemas,
+    LinkedHashMap<String, ElementSchemaArtifact> elementSchemas,
+    List<String> order,
+    LinkedHashMap<String, String> propertyLabels,
+    LinkedHashMap<String, String> propertyDescriptions)
+  {
+    Object raw = sourceNode.get(CHILDREN);
+    if (raw == null)
+      return;
+    if (!(raw instanceof List<?>))
+      throw new ArtifactParseException("Expected list value for children", CHILDREN, path);
+
+    for (Object rawChild : (List<?>) raw) {
+      if (!(rawChild instanceof LinkedHashMap<?, ?>))
+        throw new ArtifactParseException("Expected map value in children list", CHILDREN, path);
+      LinkedHashMap<String, Object> childNode = (LinkedHashMap<String, Object>) rawChild;
+
+      String childKey = readRequiredString(childNode, path, KEY, false);
+      String childType = readRequiredString(childNode, path, TYPE, false);
+      String childPath = path + "/" + childKey;
+
+      // Read override-label / override-description from the child's configuration block if present;
+      // otherwise default to the child's own name / description.
+      LinkedHashMap<String, Object> childConfig = readChildNode(childNode, childPath, CONFIGURATION);
+      String overrideLabel = childConfig != null
+        ? readString(childConfig, childPath, OVERRIDE_LABEL).orElse(null)
+        : null;
+      String overrideDescription = childConfig != null
+        ? readString(childConfig, childPath, OVERRIDE_DESCRIPTION).orElse(null)
+        : null;
+
+      if (childType.equals(ELEMENT)) {
+        ElementSchemaArtifact element = readElementSchemaArtifact(childNode, childPath);
+        elementSchemas.put(childKey, element);
+        order.add(childKey);
+        propertyLabels.put(childKey, overrideLabel != null ? overrideLabel : element.name());
+        propertyDescriptions.put(childKey, overrideDescription != null ? overrideDescription : element.description());
+      } else if (FIELD_TYPES.contains(childType)) {
+        FieldSchemaArtifact field = readFieldSchemaArtifact(childNode, childPath);
+        fieldSchemas.put(childKey, field);
+        order.add(childKey);
+        propertyLabels.put(childKey, overrideLabel != null ? overrideLabel : field.name());
+        propertyDescriptions.put(childKey, overrideDescription != null ? overrideDescription : field.description());
+      } else {
+        throw new ArtifactParseException("Unknown child type " + childType, TYPE, childPath);
+      }
+    }
   }
 
   private void checkSchemaArtifactModelVersion(LinkedHashMap<String, Object> sourceNode, String path)

--- a/src/test/java/org/metadatacenter/artifacts/model/YamlArtifactRoundTripTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/YamlArtifactRoundTripTest.java
@@ -1,12 +1,25 @@
 package org.metadatacenter.artifacts.model;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.metadatacenter.artifacts.model.core.CheckboxField;
+import org.metadatacenter.artifacts.model.core.ControlledTermField;
 import org.metadatacenter.artifacts.model.core.ElementSchemaArtifact;
+import org.metadatacenter.artifacts.model.core.EmailField;
 import org.metadatacenter.artifacts.model.core.FieldSchemaArtifact;
+import org.metadatacenter.artifacts.model.core.LinkField;
+import org.metadatacenter.artifacts.model.core.ListField;
+import org.metadatacenter.artifacts.model.core.NumericField;
+import org.metadatacenter.artifacts.model.core.PhoneNumberField;
+import org.metadatacenter.artifacts.model.core.RadioField;
 import org.metadatacenter.artifacts.model.core.TemplateSchemaArtifact;
+import org.metadatacenter.artifacts.model.core.TemporalField;
+import org.metadatacenter.artifacts.model.core.TextAreaField;
 import org.metadatacenter.artifacts.model.core.TextField;
+import org.metadatacenter.artifacts.model.core.fields.InputTimeFormat;
+import org.metadatacenter.artifacts.model.core.fields.TemporalGranularity;
+import org.metadatacenter.artifacts.model.core.fields.XsdNumericDatatype;
+import org.metadatacenter.artifacts.model.core.fields.XsdTemporalDatatype;
 import org.metadatacenter.artifacts.model.reader.YamlArtifactReader;
 import org.metadatacenter.artifacts.model.renderer.YamlArtifactRenderer;
 
@@ -26,61 +39,175 @@ public class YamlArtifactRoundTripTest
     yamlArtifactRenderer = new YamlArtifactRenderer(false);
   }
 
+  // -------- Simple schema artifacts --------
+
   @Test public void testRoundTripSimpleTemplate()
   {
-    TemplateSchemaArtifact originalTemplateSchemaArtifact = TemplateSchemaArtifact.builder()
+    TemplateSchemaArtifact original = TemplateSchemaArtifact.builder()
       .withJsonLdId(URI.create("https://repo.metadatacenter.org/templates/123")).withName("Study").build();
-
-    testRoundTripTemplateSchemaArtifact(originalTemplateSchemaArtifact);
+    roundTripTemplate(original);
   }
 
   @Test public void testRoundTripSimpleElementSchemaArtifact()
   {
-    ElementSchemaArtifact originalElementSchemaArtifact = ElementSchemaArtifact.builder()
+    ElementSchemaArtifact original = ElementSchemaArtifact.builder()
       .withJsonLdId(URI.create("https://repo.metadatacenter.org/template_elements/123")).withName("Study").build();
-
-    testRoundTripElementSchemaArtifact(originalElementSchemaArtifact);
+    roundTripElement(original);
   }
 
-  // TODO Need to activate this
-  @Disabled @Test public void testRoundTripTextField()
+  // -------- Per-field-type round trips --------
+
+  @Test public void testRoundTripTextField()
   {
-    TextField originalFieldSchemaArtifact = TextField.builder()
+    TextField original = TextField.builder()
       .withJsonLdId(URI.create("https://repo.metadatacenter.org/template_fields/123")).withName("Study")
       .withDefaultValue("A default value").withRegex("*").build();
-
-    testRoundTripFieldSchemaArtifact(originalFieldSchemaArtifact);
+    roundTripField(original);
   }
 
-  private void testRoundTripTemplateSchemaArtifact(TemplateSchemaArtifact originalTemplateSchemaArtifact)
+  @Test public void testRoundTripTextFieldWithLengthBounds()
   {
-    LinkedHashMap<String, Object> originalRendering = yamlArtifactRenderer.renderTemplateSchemaArtifact(
-      originalTemplateSchemaArtifact);
-
-    TemplateSchemaArtifact finalTemplateSchemaArtifact = yamlArtifactReader.readTemplateSchemaArtifact(
-      originalRendering);
-
-    assertEquals(originalTemplateSchemaArtifact, finalTemplateSchemaArtifact);
+    TextField original = TextField.builder().withName("ZIP").withMinLength(5).withMaxLength(5).build();
+    roundTripField(original);
   }
 
-  private void testRoundTripElementSchemaArtifact(ElementSchemaArtifact originalElementSchemaArtifact)
+  @Test public void testRoundTripTextAreaField()
   {
-    LinkedHashMap<String, Object> originalRendering = yamlArtifactRenderer.renderElementSchemaArtifact(
-      originalElementSchemaArtifact);
-
-    ElementSchemaArtifact finalElementSchemaArtifact = yamlArtifactReader.readElementSchemaArtifact(originalRendering);
-
-    assertEquals(originalElementSchemaArtifact, finalElementSchemaArtifact);
+    TextAreaField original = TextAreaField.builder().withName("Description").withMinLength(20).withMaxLength(1000)
+      .build();
+    roundTripField(original);
   }
 
-  private void testRoundTripFieldSchemaArtifact(FieldSchemaArtifact originalFieldSchemaArtifact)
+  @Test public void testRoundTripNumericField()
   {
-    LinkedHashMap<String, Object> originalRendering = yamlArtifactRenderer.renderFieldSchemaArtifact(
-      originalFieldSchemaArtifact);
-
-    FieldSchemaArtifact finalFieldSchemaArtifact = yamlArtifactReader.readFieldSchemaArtifact(originalRendering);
-
-    assertEquals(originalFieldSchemaArtifact, finalFieldSchemaArtifact);
+    // XsdNumericDatatype.INT and INTEGER both have text "xsd:int", so fromString cannot
+    // distinguish them. Use DOUBLE (unique text) for a clean round-trip.
+    NumericField original = NumericField.builder().withName("Percent").withNumericType(XsdNumericDatatype.DOUBLE)
+      .withMinValue(0).withMaxValue(100).withDefaultValue(0).build();
+    roundTripField(original);
   }
 
+  @Test public void testRoundTripTemporalField()
+  {
+    TemporalField original = TemporalField.builder().withName("Visit time")
+      .withTemporalType(XsdTemporalDatatype.DATETIME).withTemporalGranularity(TemporalGranularity.MINUTE)
+      .withInputTimeFormat(InputTimeFormat.TWENTY_FOUR_HOUR).withTimeZoneEnabled(true).build();
+    roundTripField(original);
+  }
+
+  @Test public void testRoundTripEmailField()
+  {
+    EmailField original = EmailField.builder().withName("Email").build();
+    roundTripField(original);
+  }
+
+  @Test public void testRoundTripPhoneNumberField()
+  {
+    PhoneNumberField original = PhoneNumberField.builder().withName("Phone").build();
+    roundTripField(original);
+  }
+
+  @Test public void testRoundTripRadioFieldWithOptions()
+  {
+    RadioField original = RadioField.builder().withName("Covid-19 Status").withOption("Yes").withOption("No")
+      .withOption("Maybe", true).build();
+    roundTripField(original);
+  }
+
+  @Test public void testRoundTripCheckboxFieldWithOptions()
+  {
+    CheckboxField original = CheckboxField.builder().withName("DTAP Status").withOption("Yes").withOption("No")
+      .withOption("Don't Know", true).build();
+    roundTripField(original);
+  }
+
+  @Test public void testRoundTripListFieldWithOptions()
+  {
+    ListField original = ListField.builder().withName("Vaccine").withOption("Moderna").withOption("Pfizer")
+      .withOption("None", true).build();
+    roundTripField(original);
+  }
+
+  @Test public void testRoundTripLinkField()
+  {
+    // The renderer's renderCoreValueConstraints doesn't serialize LinkDefaultValue today
+    // (handles only Text/Numeric/ControlledTerm defaults), so a default URI wouldn't round-trip.
+    // Test the plain link case for now.
+    LinkField original = LinkField.builder().withName("Institution Home Page").build();
+    roundTripField(original);
+  }
+
+  @Test public void testRoundTripControlledTermFieldWithOntologyAndClass()
+  {
+    ControlledTermField original = ControlledTermField.builder().withName("Disease")
+      .withOntologyValueConstraint(URI.create("https://data.bioontology.org/ontologies/DOID"), "DOID",
+        "Human Disease Ontology")
+      .withClassValueConstraint(URI.create("http://purl.bioontology.org/ontology/LNC/LA19711-3"), "LOINC", "Human",
+        "Human",
+        org.metadatacenter.artifacts.model.core.fields.constraints.ValueType.ONTOLOGY_CLASS)
+      .build();
+    roundTripField(original);
+  }
+
+  // -------- Schemas with child schemas --------
+
+  @Test public void testRoundTripTemplateWithSingleField()
+  {
+    TextField studyId = TextField.builder().withName("Study ID").withMinLength(2).withMaxLength(10).build();
+    TemplateSchemaArtifact original = TemplateSchemaArtifact.builder().withName("Study").withFieldSchema(studyId)
+      .build();
+    roundTripTemplate(original);
+  }
+
+  @Test public void testRoundTripTemplateWithTwoFields()
+  {
+    TextField studyId = TextField.builder().withName("Study ID").withMinLength(2).withMaxLength(10).build();
+    NumericField pct = NumericField.builder().withName("Percent").withNumericType(XsdNumericDatatype.DOUBLE)
+      .withMinValue(0).withMaxValue(100).build();
+    TemplateSchemaArtifact original = TemplateSchemaArtifact.builder().withName("Study").withFieldSchema(studyId)
+      .withFieldSchema(pct).build();
+    roundTripTemplate(original);
+  }
+
+  @Test public void testRoundTripElementWithChildField()
+  {
+    TextField zip = TextField.builder().withName("ZIP").withMinLength(5).withMaxLength(5).build();
+    ElementSchemaArtifact original = ElementSchemaArtifact.builder().withName("Address").withFieldSchema(zip).build();
+    roundTripElement(original);
+  }
+
+  @Test public void testRoundTripTemplateWithNestedElement()
+  {
+    TextField street = TextField.builder().withName("Street").build();
+    TextField zip = TextField.builder().withName("ZIP").withMinLength(5).withMaxLength(5).build();
+    ElementSchemaArtifact address = ElementSchemaArtifact.builder().withName("Address").withFieldSchema(street)
+      .withFieldSchema(zip).build();
+    TextField studyId = TextField.builder().withName("Study ID").build();
+    TemplateSchemaArtifact original = TemplateSchemaArtifact.builder().withName("Study").withFieldSchema(studyId)
+      .withElementSchema(address).build();
+    roundTripTemplate(original);
+  }
+
+  // -------- Round-trip helpers --------
+
+  private void roundTripTemplate(TemplateSchemaArtifact original)
+  {
+    LinkedHashMap<String, Object> rendering = yamlArtifactRenderer.renderTemplateSchemaArtifact(original);
+    TemplateSchemaArtifact roundTripped = yamlArtifactReader.readTemplateSchemaArtifact(rendering);
+    assertEquals(original, roundTripped);
+  }
+
+  private void roundTripElement(ElementSchemaArtifact original)
+  {
+    LinkedHashMap<String, Object> rendering = yamlArtifactRenderer.renderElementSchemaArtifact(original);
+    ElementSchemaArtifact roundTripped = yamlArtifactReader.readElementSchemaArtifact(rendering);
+    assertEquals(original, roundTripped);
+  }
+
+  private void roundTripField(FieldSchemaArtifact original)
+  {
+    LinkedHashMap<String, Object> rendering = yamlArtifactRenderer.renderFieldSchemaArtifact(original);
+    FieldSchemaArtifact roundTripped = yamlArtifactReader.readFieldSchemaArtifact(rendering);
+    assertEquals(original, roundTripped);
+  }
 }


### PR DESCRIPTION
Phase A of completing the YAML reader to be symmetric with the already-complete renderer. Item 1 from the remaining list.

## Background

The simple round-trip tests in \`YamlArtifactRoundTripTest\` only passed because they used artifacts with no children and no value constraints — those happened to match the Reader's empty-map / null stubs. The TextField round-trip test was \`@Disabled\` because the Reader couldn't read \`defaultValue\` or \`regex\`.

This PR teaches the Reader how to walk the YAML shape the Renderer actually produces.

## Reader changes

- **\`readChildSchemas\`** — walk the \`children:\` list, dispatch by \`type\` to field/element readers, and thread \`order\` / \`propertyLabels\` / \`propertyDescriptions\` through so the Ui shape matches what the builder produces. Honors \`overrideLabel\` / \`overrideDescription\` in each child's \`configuration:\` block.
- **\`readValueConstraints\`** rewritten to match the renderer's actual YAML shape: \`minLength\` / \`maxLength\` / \`regex\` / \`default\` / \`datatype\` / \`minValue\` / \`maxValue\` / \`decimalPlaces\` / \`unit\` at the field level, \`values:\` as a typed list (ontology / class / branch / valueSet / literal), \`actions:\` as a separate list, and \`required\` / \`recommended\` from the \`configuration:\` sub-block.
- **LINK fields now build \`LinkValueConstraints\`**, not \`ControlledTermValueConstraints\`.
- **Value-constraint list readers implemented**: ontology / class / branch / value-set / literal constraints, plus actions.
- **Typed default-value readers**: text / numeric / temporal / controlled-term / link.
- **\`readFieldInputType\` extended** to cover the full \`FieldInputType\` set (PHONE_NUMBER, EMAIL, LINK, ROR, ORCID, PFAS, RRID, PUBMED, NIH_GRANT_ID, DOI, ATTRIBUTE_VALUE, plus the four static-content types). Multi/single-select-list now correctly map to \`FieldInputType.LIST\` (was \`CHECKBOX\`). \`multipleChoice\` is derived from input type for checkbox.
- **Configuration-sub-block-aware**: \`isMultiple\` / \`minItems\` / \`maxItems\` / \`propertyUri\` for nested elements and fields are read from \`configuration:\` first; falls back to field level for backwards compat with the existing reader tests.
- **\`checkSchemaArtifactModelVersion\`** now runs only at public entry points, not on nested children (which never carry a top-level \`modelVersion\` key).
- **\`readChildNode\`** now returns \`null\` when absent (was returning an empty \`LinkedHashMap\`, masking absence). **\`readString2StringMap\`** actually walks the map now.
- New **\`readEnumOrString\`** helper accepts \`String\`, \`Enum\`, or \`Optional\` values — the renderer leaves some values un-stringified in the in-memory map.

## Tests (15 new round-trips)

- **Per-field-type**: TextField (with \`default\` + \`regex\` — was \`@Disabled\`, now enabled), TextField with min/max length, TextArea, Numeric, Temporal, Email, PhoneNumber, Radio with options, Checkbox with options, List with options, Link, ControlledTerm with ontology + class values.
- **Composite**: Template with single field, template with two fields, element with child field, template with nested element with field children.

## Pre-existing bugs surfaced (out of scope, noted in test comments)

1. **\`XsdNumericDatatype.INT\` and \`XsdNumericDatatype.INTEGER\`** both have text \`"xsd:int"\` — \`fromString\` cannot disambiguate on round-trip. The numeric round-trip tests use \`DOUBLE\` (unique text) to avoid the clash.
2. **The renderer's \`renderCoreValueConstraints\`** serializes only Text / Numeric / ControlledTerm defaults; \`LinkDefaultValue\` is silently dropped. The LinkField test therefore doesn't exercise a default URI.

## Deferred to follow-ups (PR B and PR C)

- \`readTemplateInstanceArtifact\` (currently returns \`null\`)
- \`readAnnotations\` (returns \`Optional.empty\`)
- Top-level \`CONFIGURATIONS\` section parsing

## Test plan

- [x] \`mvn clean test\` → 285 tests, 0 failures, 2 pre-existing skips (was 3 — one was the now-enabled \`testRoundTripTextField\`)
- [x] \`mvn spotless:check\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)