### PR TITLE
YamlArtifactReader: attribute-value field groups and richer instance shapes (PR C)

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReader.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReader.java
@@ -52,6 +52,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ACRONYM;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ACTION;
@@ -90,6 +91,7 @@ import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MAX_LENGTH;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MAX_VALUE;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MIN_LENGTH;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.MIN_VALUE;
+import static org.metadatacenter.artifacts.model.yaml.YamlConstants.NOTATION;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.NUM_TERMS;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ONTOLOGY;
 import static org.metadatacenter.artifacts.model.yaml.YamlConstants.ONTOLOGY_NAME;
@@ -338,6 +340,9 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
       }
     });
 
+    readAttributeValueFieldInstanceGroups(sourceNode, path, TEMPLATE_INSTANCE_RESERVED_KEYS,
+      builder::withAttributeValueFieldGroup);
+
     readAnnotations(sourceNode, path).ifPresent(builder::withAnnotations);
 
     return builder.build();
@@ -425,7 +430,58 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
       }
     });
 
+    readAttributeValueFieldInstanceGroups(sourceNode, path, ELEMENT_INSTANCE_RESERVED_KEYS,
+      builder::withAttributeValueFieldGroup);
+
     return builder.build();
+  }
+
+  /**
+   * Top-level YAML keys reserved by the template-instance renderer. Any other top-level key is
+   * treated as an attribute-value field instance group whose value is a map of attribute names
+   * to field instances.
+   */
+  private static final Set<String> TEMPLATE_INSTANCE_RESERVED_KEYS = Set.of(
+    TYPE, NAME, DESCRIPTION, ID, IS_BASED_ON,
+    CREATED_BY, MODIFIED_BY, CREATED_ON, MODIFIED_ON,
+    CHILDREN, ANNOTATIONS);
+
+  /**
+   * Top-level YAML keys reserved by the element-instance renderer. Element instances are nested
+   * (they appear as values in a parent's {@code children:} map) and only ever carry {@code id}
+   * and {@code children} as reserved keys.
+   */
+  private static final Set<String> ELEMENT_INSTANCE_RESERVED_KEYS = Set.of(ID, CHILDREN);
+
+  /**
+   * Walk top-level keys of an instance YAML map looking for attribute-value field groups. Each
+   * non-reserved key whose value is a map is treated as a group; each entry in that map is
+   * read as a {@link FieldInstanceArtifact} (so the inner shape is the same one written by
+   * {@code renderAttributeValueFieldInstanceGroupFields}).
+   */
+  @SuppressWarnings("unchecked")
+  private void readAttributeValueFieldInstanceGroups(LinkedHashMap<String, Object> sourceNode, String path,
+    Set<String> reservedKeys, java.util.function.BiConsumer<String, LinkedHashMap<String, FieldInstanceArtifact>> sink)
+  {
+    for (Map.Entry<String, Object> entry : sourceNode.entrySet()) {
+      String key = entry.getKey();
+      if (reservedKeys.contains(key))
+        continue;
+      Object rawValue = entry.getValue();
+      if (!(rawValue instanceof LinkedHashMap<?, ?>))
+        continue;
+      LinkedHashMap<String, Object> groupNode = (LinkedHashMap<String, Object>) rawValue;
+      LinkedHashMap<String, FieldInstanceArtifact> groupFields = new LinkedHashMap<>();
+      for (Map.Entry<String, Object> fieldEntry : groupNode.entrySet()) {
+        String fieldName = fieldEntry.getKey();
+        Object fieldRaw = fieldEntry.getValue();
+        if (!(fieldRaw instanceof LinkedHashMap<?, ?>))
+          throw new ArtifactParseException("Expected map value for attribute-value field " + fieldName, key, path);
+        groupFields.put(fieldName,
+          readFieldInstanceArtifact((LinkedHashMap<String, Object>) fieldRaw, path + "/" + key + "/" + fieldName));
+      }
+      sink.accept(key, groupFields);
+    }
   }
 
   /**
@@ -442,8 +498,8 @@ public class YamlArtifactReader implements ArtifactReader<LinkedHashMap<String, 
       jsonLdTypes.add(URI.create(datatype.get()));
     Optional<URI> jsonLdId = readUri(sourceNode, path, ID);
     Optional<String> jsonLdValue = readString(sourceNode, path, VALUE, true);
-    Optional<String> label = readString(sourceNode, path, "label", true);
-    Optional<String> notation = readString(sourceNode, path, "notation", true);
+    Optional<String> label = readString(sourceNode, path, LABEL, true);
+    Optional<String> notation = readString(sourceNode, path, NOTATION, true);
     Optional<String> preferredLabel = readString(sourceNode, path, PREF_LABEL, true);
     Optional<String> language = readString(sourceNode, path, LANGUAGE);
 

--- a/src/test/java/org/metadatacenter/artifacts/model/YamlArtifactRoundTripTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/YamlArtifactRoundTripTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.metadatacenter.artifacts.model.core.Annotations;
 import org.metadatacenter.artifacts.model.core.CheckboxField;
 import org.metadatacenter.artifacts.model.core.ControlledTermField;
+import org.metadatacenter.artifacts.model.core.ElementInstanceArtifact;
 import org.metadatacenter.artifacts.model.core.ElementSchemaArtifact;
 import org.metadatacenter.artifacts.model.core.EmailField;
 import org.metadatacenter.artifacts.model.core.FieldInstanceArtifact;
@@ -249,7 +250,93 @@ public class YamlArtifactRoundTripTest
     roundTripTemplateInstance(original);
   }
 
+  @Test public void testRoundTripTemplateInstanceWithMultiInstanceFields()
+  {
+    FieldInstanceArtifact keyword1 = simpleLiteralField("immunology");
+    FieldInstanceArtifact keyword2 = simpleLiteralField("oncology");
+
+    TemplateInstanceArtifact original = TemplateInstanceArtifact.builder().withName("SDY232")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withMultiInstanceFieldInstances("keywords", java.util.List.of(keyword1, keyword2))
+      .build();
+    roundTripTemplateInstance(original);
+  }
+
+  @Test public void testRoundTripTemplateInstanceWithNestedElement()
+  {
+    FieldInstanceArtifact street = simpleLiteralField("123 Main St");
+    FieldInstanceArtifact city = simpleLiteralField("Palo Alto");
+    ElementInstanceArtifact address = ElementInstanceArtifact.builder()
+      .withSingleInstanceFieldInstance("Street", street)
+      .withSingleInstanceFieldInstance("City", city)
+      .build();
+
+    TemplateInstanceArtifact original = TemplateInstanceArtifact.builder().withName("SDY232")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withSingleInstanceElementInstance("Address", address)
+      .build();
+    roundTripTemplateInstance(original);
+  }
+
+  @Test public void testRoundTripTemplateInstanceWithMultiInstanceElements()
+  {
+    FieldInstanceArtifact street1 = simpleLiteralField("123 Main St");
+    ElementInstanceArtifact address1 = ElementInstanceArtifact.builder()
+      .withSingleInstanceFieldInstance("Street", street1).build();
+    FieldInstanceArtifact street2 = simpleLiteralField("742 Evergreen Tce");
+    ElementInstanceArtifact address2 = ElementInstanceArtifact.builder()
+      .withSingleInstanceFieldInstance("Street", street2).build();
+
+    TemplateInstanceArtifact original = TemplateInstanceArtifact.builder().withName("SDY232")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withMultiInstanceElementInstances("Addresses", java.util.List.of(address1, address2))
+      .build();
+    roundTripTemplateInstance(original);
+  }
+
+  @Test public void testRoundTripTemplateInstanceWithAttributeValueFieldGroup()
+  {
+    FieldInstanceArtifact attr1 = simpleLiteralField("foo");
+    FieldInstanceArtifact attr2 = simpleLiteralField("bar");
+    LinkedHashMap<String, FieldInstanceArtifact> group = new LinkedHashMap<>();
+    group.put("attr1", attr1);
+    group.put("attr2", attr2);
+
+    TemplateInstanceArtifact original = TemplateInstanceArtifact.builder().withName("SDY232")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withAttributeValueFieldGroup("custom-attrs", group)
+      .build();
+    roundTripTemplateInstance(original);
+  }
+
+  @Test public void testRoundTripElementInstanceWithAttributeValueFieldGroup()
+  {
+    FieldInstanceArtifact attr = simpleLiteralField("foo");
+    LinkedHashMap<String, FieldInstanceArtifact> group = new LinkedHashMap<>();
+    group.put("attr1", attr);
+
+    ElementInstanceArtifact address = ElementInstanceArtifact.builder()
+      .withSingleInstanceFieldInstance("Street", simpleLiteralField("Main"))
+      .withAttributeValueFieldGroup("ext-attrs", group)
+      .build();
+
+    TemplateInstanceArtifact original = TemplateInstanceArtifact.builder().withName("SDY232")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withSingleInstanceElementInstance("Address", address)
+      .build();
+    roundTripTemplateInstance(original);
+  }
+
   // -------- Round-trip helpers --------
+
+  private static FieldInstanceArtifact simpleLiteralField(String value)
+  {
+    return FieldInstanceArtifact.create(
+      java.util.Collections.emptyList(), java.util.Optional.empty(),
+      java.util.Optional.of(value), java.util.Optional.empty(), java.util.Optional.empty(),
+      java.util.Optional.empty(), java.util.Optional.empty());
+  }
+
 
   private void roundTripTemplateInstance(TemplateInstanceArtifact original)
   {


### PR DESCRIPTION
## Summary
Completes the YamlArtifactReader / YamlArtifactRenderer symmetry for instance artifacts.

- Reads top-level **attribute-value field instance groups** for template and element instances. The renderer writes these as top-level keys (alongside `name`, `isBasedOn`, `children`, etc.); the reader now distinguishes them from reserved metadata via per-artifact reserved-key sets (`TEMPLATE_INSTANCE_RESERVED_KEYS`, `ELEMENT_INSTANCE_RESERVED_KEYS`).
- Switches the `label:` / `notation:` lookups in `readFieldInstanceArtifact` to the shared `YamlConstants` instead of inline string literals.

Five new round-trip tests:
- Multi-instance fields
- Single nested element
- Multi-instance elements
- Attribute-value group on a template instance
- Attribute-value group on a nested element instance

## Test plan
- [x] `mvn test` — 295 passed (5 new), 0 failures
- [x] `mvn spotless:check` — clean
- [ ] Reviewer eyeballs `readAttributeValueFieldInstanceGroups` and the reserved-key sets

## Scope notes
Third and final PR in the YamlArtifactReader completion series (PR A: child schemas + value constraints + defaults #40; PR B: annotations + basic instance reading #41; this one). With this merged, `YamlArtifactReader` no longer has TODO/stub methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)