### PR TITLE
JsonNodeReaders: stop silently coercing malformed/missing versions

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/reader/JsonArtifactShapeChecks.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/reader/JsonArtifactShapeChecks.java
@@ -5,6 +5,7 @@ import org.metadatacenter.artifacts.model.core.Version;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 import static org.metadatacenter.artifacts.model.reader.JsonArtifactShapeChecks.*;
 import static org.metadatacenter.artifacts.model.reader.JsonNodeReaders.*;
@@ -96,10 +97,10 @@ final class JsonArtifactShapeChecks {
 
 
   public static void checkSchemaArtifactModelVersion(ObjectNode sourceNode, String path) {
-    Version artifactModelVersion = readModelVersion(sourceNode, path);
+    Optional<Version> artifactModelVersion = readModelVersion(sourceNode, path);
 
     // TODO Renable eventually after patching older artifacts
-    //    if (!artifactModelVersion.equals(MODEL_VERSION))
+    //    if (artifactModelVersion.isEmpty() || !artifactModelVersion.get().equals(MODEL_VERSION))
     //      throw new ArtifactParseException("Expecting model version " + MODEL_VERSION + ", got " +
     //      artifactModelVersion,
     //        SCHEMA_ORG_SCHEMA_VERSION, path);

--- a/src/main/java/org/metadatacenter/artifacts/model/reader/JsonNodeReaders.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/reader/JsonNodeReaders.java
@@ -250,16 +250,13 @@ final class JsonNodeReaders {
   public static Optional<Version> readVersion(ObjectNode sourceNode, String path, String fieldKey) {
     Optional<String> version = readString(sourceNode, path, fieldKey);
 
-    if (version.isEmpty()) {
+    if (version.isEmpty())
       return Optional.empty();
-    } else {
-      if (Version.isValidVersion(version.get())) {
-        return Optional.of(Version.fromString(version.get()));
-      } else // TODO Revisit this silent version fix
-      {
-        return Optional.of(Version.fromString("0.0.1"));
-      }
-    }
+
+    if (!Version.isValidVersion(version.get()))
+      throw new ArtifactParseException("Invalid version " + version.get(), fieldKey, path);
+
+    return Optional.of(Version.fromString(version.get()));
   }
 
 
@@ -502,14 +499,17 @@ final class JsonNodeReaders {
   }
 
 
-  public static Version readModelVersion(ObjectNode sourceNode, String path) {
+  public static Optional<Version> readModelVersion(ObjectNode sourceNode, String path) {
     Optional<String> versionString = readString(sourceNode, path, SCHEMA_ORG_SCHEMA_VERSION);
 
-    if (versionString.isPresent()) {
-      return Version.fromString(versionString.get());
-    } else {
-      return Version.fromString("1.6.0"); // TODO Temporarily supply version
-    }
+    if (versionString.isEmpty())
+      return Optional.empty();
+
+    if (!Version.isValidVersion(versionString.get()))
+      throw new ArtifactParseException("Invalid model version " + versionString.get(),
+        SCHEMA_ORG_SCHEMA_VERSION, path);
+
+    return Optional.of(Version.fromString(versionString.get()));
   }
 
 

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/JsonNodeReadersTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/JsonNodeReadersTest.java
@@ -1,0 +1,85 @@
+package org.metadatacenter.artifacts.model.reader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.metadatacenter.artifacts.model.core.Version;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.metadatacenter.model.ModelNodeNames.PAV_VERSION;
+import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_SCHEMA_VERSION;
+
+public class JsonNodeReadersTest
+{
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test public void readVersionReturnsParsedVersionWhenPresent()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put(PAV_VERSION, "2.1.3");
+
+    Optional<Version> result = JsonNodeReaders.readVersion(node, "/", PAV_VERSION);
+
+    assertTrue(result.isPresent());
+    assertEquals(Version.fromString("2.1.3"), result.get());
+  }
+
+  @Test public void readVersionReturnsEmptyWhenAbsent()
+  {
+    ObjectNode node = mapper.createObjectNode();
+
+    Optional<Version> result = JsonNodeReaders.readVersion(node, "/", PAV_VERSION);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test public void readVersionThrowsOnInvalidVersionString()
+  {
+    // Regression test: previously this silently rewrote invalid version strings to "0.0.1",
+    // masking malformed input.
+    ObjectNode node = mapper.createObjectNode();
+    node.put(PAV_VERSION, "not-a-version");
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> JsonNodeReaders.readVersion(node, "/", PAV_VERSION));
+    assertTrue(ex.getMessage().contains("not-a-version"),
+      "Exception message should mention the invalid version. Got: " + ex.getMessage());
+  }
+
+  @Test public void readModelVersionReturnsParsedVersionWhenPresent()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put(SCHEMA_ORG_SCHEMA_VERSION, "1.6.0");
+
+    Optional<Version> result = JsonNodeReaders.readModelVersion(node, "/");
+
+    assertTrue(result.isPresent());
+    assertEquals(Version.fromString("1.6.0"), result.get());
+  }
+
+  @Test public void readModelVersionReturnsEmptyWhenAbsent()
+  {
+    // Regression test: previously this silently defaulted to "1.6.0", masking documents that
+    // never declared a model version.
+    ObjectNode node = mapper.createObjectNode();
+
+    Optional<Version> result = JsonNodeReaders.readModelVersion(node, "/");
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test public void readModelVersionThrowsOnInvalidVersionString()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put(SCHEMA_ORG_SCHEMA_VERSION, "garbage");
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> JsonNodeReaders.readModelVersion(node, "/"));
+    assertTrue(ex.getMessage().contains("garbage"),
+      "Exception message should mention the invalid version. Got: " + ex.getMessage());
+  }
+}


### PR DESCRIPTION
## Summary
Two read paths in `JsonNodeReaders` previously rewrote bad data without telling the caller:

- **`readVersion`** rewrote any invalid version string to `"0.0.1"`. `YamlArtifactReader.readVersion` already throws in this case — this brings the JSON path in line.
- **`readModelVersion`** silently substituted `"1.6.0"` (the current model version) for a missing `schema:schemaVersion`. That's the worst possible default — it falsely asserts conformance to the current model spec. Change return type to `Optional<Version>` so callers can see the absence explicitly. Update the only caller (the no-op shape check in `JsonArtifactShapeChecks` that's commented out pending an older-artifact patch effort) to handle the Optional.

Both methods now throw `ArtifactParseException` on malformed strings with a message that includes the offending value.

## Test plan
- [x] New `JsonNodeReadersTest` — 6 focused tests (present/absent/malformed for both methods)
- [x] `mvn test` — 301 passing (6 new), 0 failures
- [x] `mvn spotless:check` — clean
- [ ] Reviewer eyeballs the `Optional<Version>` API change on `readModelVersion`

## Notes
- The disabled model-version equality check in `JsonArtifactShapeChecks.checkSchemaArtifactModelVersion` is left disabled (its TODO is a separate concern); the body is updated to compile against the new `Optional<Version>` return type.
- The error-on-invalid-version behavior could in principle break ingestion of legacy artifacts with malformed `pav:version`. The existing test fixtures (`testReadSampleBlockTemplateSchemaArtifact`, etc.) all pass, but flagging in case you know of any in-the-wild artifacts with non-semver `pav:version` strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)