### PR TITLE
Test coverage batch 2: +50 tests across reader negative paths, asymmetry probes, contract pinning

### DIFF
--- a/src/test/java/org/metadatacenter/artifacts/model/AnnotationsEqualityAndOrderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/AnnotationsEqualityAndOrderTest.java
@@ -1,0 +1,71 @@
+package org.metadatacenter.artifacts.model;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.metadatacenter.artifacts.model.core.Annotations;
+import org.metadatacenter.artifacts.model.core.TemplateSchemaArtifact;
+import org.metadatacenter.artifacts.model.reader.JsonArtifactReader;
+import org.metadatacenter.artifacts.model.renderer.JsonArtifactRenderer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Group K — Annotations equality and JSON round-trip ordering. Annotations is a record
+ * around a LinkedHashMap; the equality semantics and the JSON renderer's ordering both
+ * deserve explicit pinning.
+ */
+public class AnnotationsEqualityAndOrderTest
+{
+  private JsonArtifactReader reader;
+  private JsonArtifactRenderer renderer;
+
+  @BeforeEach public void setup()
+  {
+    reader = new JsonArtifactReader();
+    renderer = new JsonArtifactRenderer();
+  }
+
+  @Test public void testAnnotationsEqualityIgnoresInsertionOrder()
+  {
+    // Annotations is a record wrapping a LinkedHashMap; LinkedHashMap.equals checks
+    // entry-by-entry without regard to insertion order. Pin this contract — if someone
+    // refactors equality to be order-sensitive, downstream callers that compare annotations
+    // built in different orders would silently break.
+    Annotations a = Annotations.builder()
+      .withLiteralAnnotation("x", "1")
+      .withLiteralAnnotation("y", "2")
+      .build();
+    Annotations b = Annotations.builder()
+      .withLiteralAnnotation("y", "2")
+      .withLiteralAnnotation("x", "1")
+      .build();
+
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test public void testJsonRoundTripPreservesAnnotationInsertionOrder()
+  {
+    // Even though equality is order-insensitive, the renderer's *output* should be ordered
+    // (so YAML/JSON files have stable diffs). Verify the round-tripped Annotations preserves
+    // the original insertion order.
+    Annotations annotations = Annotations.builder()
+      .withLiteralAnnotation("z", "1")
+      .withLiteralAnnotation("a", "2")
+      .withLiteralAnnotation("m", "3")
+      .build();
+    TemplateSchemaArtifact original = TemplateSchemaArtifact.builder().withName("T")
+      .withAnnotations(annotations).build();
+
+    ObjectNode json = renderer.renderTemplateSchemaArtifact(original);
+    TemplateSchemaArtifact roundTripped = reader.readTemplateSchemaArtifact(json);
+
+    List<String> keys = new ArrayList<>(roundTripped.annotations().get().annotations().keySet());
+    assertEquals(List.of("z", "a", "m"), keys,
+      "Annotation insertion order lost through JSON round-trip");
+  }
+}

--- a/src/test/java/org/metadatacenter/artifacts/model/JsonAttributeValueRoundTripTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/JsonAttributeValueRoundTripTest.java
@@ -1,0 +1,105 @@
+package org.metadatacenter.artifacts.model;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.metadatacenter.artifacts.model.core.FieldInstanceArtifact;
+import org.metadatacenter.artifacts.model.core.TemplateInstanceArtifact;
+import org.metadatacenter.artifacts.model.reader.JsonArtifactReader;
+import org.metadatacenter.artifacts.model.renderer.JsonArtifactRenderer;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Group J — focused JSON round-trip tests for attribute-value field groups. Existing
+ * JsonArtifactRoundTripTest covers attribute-value via fixture files but asserts on the
+ * whole artifact's equality — these tests pin the specific contract on
+ * {@code attributeValueFieldInstanceGroups()} so a regression in the JSON shape (the
+ * "array of names + sibling single instances" form) doesn't slip past.
+ */
+public class JsonAttributeValueRoundTripTest
+{
+  private JsonArtifactReader reader;
+  private JsonArtifactRenderer renderer;
+
+  @BeforeEach public void setup()
+  {
+    reader = new JsonArtifactReader();
+    renderer = new JsonArtifactRenderer();
+  }
+
+  private static FieldInstanceArtifact literal(String value)
+  {
+    return FieldInstanceArtifact.create(java.util.Collections.emptyList(), Optional.empty(),
+      Optional.of(value), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  @Test public void testJsonRoundTripPreservesAttributeValueGroupNameAndEntries()
+  {
+    LinkedHashMap<String, FieldInstanceArtifact> group = new LinkedHashMap<>();
+    group.put("attr1", literal("foo"));
+    group.put("attr2", literal("bar"));
+
+    TemplateInstanceArtifact original = TemplateInstanceArtifact.builder().withName("Inst")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withAttributeValueFieldGroup("custom-attrs", group)
+      .build();
+
+    ObjectNode json = renderer.renderTemplateInstanceArtifact(original);
+    TemplateInstanceArtifact roundTripped = reader.readTemplateInstanceArtifact(json);
+
+    Map<String, Map<String, FieldInstanceArtifact>> groups = roundTripped.attributeValueFieldInstanceGroups();
+    assertTrue(groups.containsKey("custom-attrs"),
+      "Group name lost; got keys " + groups.keySet());
+    assertEquals(2, groups.get("custom-attrs").size());
+    assertEquals("foo", groups.get("custom-attrs").get("attr1").jsonLdValue().get());
+    assertEquals("bar", groups.get("custom-attrs").get("attr2").jsonLdValue().get());
+  }
+
+  @Test public void testJsonRoundTripPreservesAttributeValueEntryOrder()
+  {
+    // The renderer serializes via an array of names + sibling single instances; entry order
+    // must survive the round-trip (UI consumers display fields in this order).
+    LinkedHashMap<String, FieldInstanceArtifact> group = new LinkedHashMap<>();
+    group.put("z-attr", literal("3"));
+    group.put("a-attr", literal("1"));
+    group.put("m-attr", literal("2"));
+
+    TemplateInstanceArtifact original = TemplateInstanceArtifact.builder().withName("Inst")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withAttributeValueFieldGroup("custom", group).build();
+
+    ObjectNode json = renderer.renderTemplateInstanceArtifact(original);
+    TemplateInstanceArtifact roundTripped = reader.readTemplateInstanceArtifact(json);
+
+    List<String> keys = new ArrayList<>(
+      roundTripped.attributeValueFieldInstanceGroups().get("custom").keySet());
+    assertEquals(List.of("z-attr", "a-attr", "m-attr"), keys);
+  }
+
+  @Test public void testJsonRoundTripWithEmptyAttributeValueGroupRendersWithoutError()
+  {
+    // Empty group is a degenerate case — the renderer's behavior here defines whether such
+    // a group survives at all. We don't assert it's preserved; we just pin that the round-trip
+    // doesn't throw, so consumers can pass through these instances safely.
+    TemplateInstanceArtifact original = TemplateInstanceArtifact.builder().withName("Inst")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withAttributeValueFieldGroup("empty", new LinkedHashMap<>())
+      .build();
+
+    ObjectNode json = renderer.renderTemplateInstanceArtifact(original);
+    TemplateInstanceArtifact roundTripped = reader.readTemplateInstanceArtifact(json);
+
+    // Either the group survives (empty) or it gets dropped — both are acceptable; we just
+    // want the round-trip itself not to throw.
+    assertEquals("Inst", roundTripped.name().get());
+  }
+}

--- a/src/test/java/org/metadatacenter/artifacts/model/YamlAsymmetryProbeTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/YamlAsymmetryProbeTest.java
@@ -1,0 +1,119 @@
+package org.metadatacenter.artifacts.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.metadatacenter.artifacts.model.core.ControlledTermField;
+import org.metadatacenter.artifacts.model.core.FieldSchemaArtifact;
+import org.metadatacenter.artifacts.model.core.NumericField;
+import org.metadatacenter.artifacts.model.core.TemporalField;
+import org.metadatacenter.artifacts.model.core.YouTubeField;
+import org.metadatacenter.artifacts.model.core.fields.InputTimeFormat;
+import org.metadatacenter.artifacts.model.core.fields.TemporalGranularity;
+import org.metadatacenter.artifacts.model.core.fields.XsdNumericDatatype;
+import org.metadatacenter.artifacts.model.core.fields.XsdTemporalDatatype;
+import org.metadatacenter.artifacts.model.core.fields.constraints.NumericValueConstraints;
+import org.metadatacenter.artifacts.model.core.ui.StaticFieldUi;
+import org.metadatacenter.artifacts.model.reader.YamlArtifactReader;
+import org.metadatacenter.artifacts.model.renderer.YamlArtifactRenderer;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Group E — round-trip *probes* targeted at fields the Explore survey flagged as potentially
+ * being silently dropped by the YAML renderer / reader pair. If these tests pass, we confirm
+ * symmetry; if they ever fail, we found a real silent-data-loss bug.
+ */
+public class YamlAsymmetryProbeTest
+{
+  private YamlArtifactReader reader;
+  private YamlArtifactRenderer renderer;
+
+  @BeforeEach public void setup()
+  {
+    reader = new YamlArtifactReader();
+    renderer = new YamlArtifactRenderer(false);
+  }
+
+  // Captured as part of this PR: the renderer emits width/height but the reader doesn't
+  // wire them through for static fields. Disabled until the asymmetry is fixed; re-enable
+  // when YamlArtifactReader.readFieldUi handles static-field width/height.
+  @Disabled("Round-trip silently drops width/height on YouTube/Image fields — separate fix")
+  @Test public void testRoundTripPreservesYouTubeWidthHeight()
+  {
+    // Width/height live on YouTubeFieldUiBuilder; the field builder itself doesn't expose them.
+    StaticFieldUi ytUi = StaticFieldUi.youTubeFieldUiBuilder()
+      .withContent("dQw4w9WgXcQ").withWidth(640).withHeight(480).build();
+    YouTubeField original = YouTubeField.builder()
+      .withName("Demo Video").withFieldUi(ytUi).build();
+
+    FieldSchemaArtifact roundTripped = roundTripField(original);
+
+    assertEquals(640, roundTripped.fieldUi().asStaticFieldUi().width().get());
+    assertEquals(480, roundTripped.fieldUi().asStaticFieldUi().height().get());
+  }
+
+  // Captured as part of this PR: the renderer emits `valueRecommendation:` when the field UI
+  // flag is true, but the round-tripped artifact comes back with the flag false. The reader's
+  // readFieldUi reads VALUE_RECOMMENDATION at the field level, but the renderer emits it under
+  // the controlled-term values block (or vice versa). Disabled until the location agrees.
+  @Disabled("Round-trip silently drops valueRecommendation flag — separate fix")
+  @Test public void testRoundTripPreservesValueRecommendationOnControlledTerm()
+  {
+    // The renderer emits `valueRecommendation:` only when true; this is a real round-trip probe.
+    ControlledTermField original = ControlledTermField.builder()
+      .withName("Disease").withValueRecommendationEnabled(true).build();
+
+    FieldSchemaArtifact roundTripped = roundTripField(original);
+
+    assertEquals(true, roundTripped.fieldUi().valueRecommendationEnabled());
+  }
+
+  @Test public void testRoundTripPreservesNumericDecimalPlaces()
+  {
+    NumericField original = NumericField.builder().withName("pH")
+      .withNumericType(XsdNumericDatatype.DECIMAL)
+      .withDecimalPlaces(2).build();
+
+    FieldSchemaArtifact roundTripped = roundTripField(original);
+
+    NumericValueConstraints vc = (NumericValueConstraints) roundTripped.valueConstraints().get();
+    assertEquals(2, vc.decimalPlace().get());
+  }
+
+  @Test public void testRoundTripPreservesTemporalInputTimeFormat()
+  {
+    TemporalField original = TemporalField.builder().withName("When")
+      .withTemporalType(XsdTemporalDatatype.DATETIME)
+      .withTemporalGranularity(TemporalGranularity.MINUTE)
+      .withInputTimeFormat(InputTimeFormat.TWENTY_FOUR_HOUR).build();
+
+    FieldSchemaArtifact roundTripped = roundTripField(original);
+
+    assertEquals(InputTimeFormat.TWENTY_FOUR_HOUR,
+      roundTripped.fieldUi().asTemporalFieldUi().inputTimeFormat().get());
+  }
+
+  @Test public void testRoundTripPreservesTemporalGranularity()
+  {
+    // Each granularity has a different code path in the renderer; SECOND specifically must
+    // round-trip without being widened to MINUTE.
+    TemporalField original = TemporalField.builder().withName("When")
+      .withTemporalType(XsdTemporalDatatype.DATETIME)
+      .withTemporalGranularity(TemporalGranularity.SECOND)
+      .withInputTimeFormat(InputTimeFormat.TWENTY_FOUR_HOUR).build();
+
+    FieldSchemaArtifact roundTripped = roundTripField(original);
+
+    assertEquals(TemporalGranularity.SECOND,
+      roundTripped.fieldUi().asTemporalFieldUi().temporalGranularity());
+  }
+
+  private FieldSchemaArtifact roundTripField(FieldSchemaArtifact original)
+  {
+    LinkedHashMap<String, Object> rendering = renderer.renderFieldSchemaArtifact(original);
+    return reader.readFieldSchemaArtifact(rendering);
+  }
+}

--- a/src/test/java/org/metadatacenter/artifacts/model/core/CoreContractPinningTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/CoreContractPinningTest.java
@@ -1,0 +1,65 @@
+package org.metadatacenter.artifacts.model.core;
+
+import org.junit.jupiter.api.Test;
+import org.metadatacenter.artifacts.model.core.fields.XsdNumericDatatype;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Groups H + L — small contracts worth pinning.
+ *
+ * <p>**H1.** {@code XsdNumericDatatype.fromString("xsd:int")} has a documented ambiguity:
+ * both {@code INTEGER("xsd:int")} and {@code INT("xsd:int")} match. The current
+ * enum-declaration-order behavior returns {@code INTEGER}. If someone reorders the constants,
+ * callers downstream silently switch to {@code INT} (or fail equality checks). This test
+ * pins the current behavior.
+ *
+ * <p>**L1.** {@code FieldInstanceArtifact.create} must accept an empty {@code jsonLdTypes}
+ * list — this is the normal shape for plain literal field instances. Pin it so a future
+ * refactor doesn't add a "required" guard.
+ *
+ * <p>**L2.** {@code Status.fromString} rejects unknown strings (mirrors the version contract
+ * locked in by PR #43).
+ */
+public class CoreContractPinningTest
+{
+  @Test public void testXsdNumericDatatypeIntStringIsDeterministicallyInteger()
+  {
+    // INTEGER is declared before INT in the enum (lines 12, 16 of XsdNumericDatatype.java),
+    // so the fromString iteration matches INTEGER first. This test pins that ordering — if
+    // the enum members are ever reordered, this test fails loudly rather than letting the
+    // ambiguity silently flip downstream callers (e.g., JsonValueConstraintsReader L330).
+    XsdNumericDatatype result = XsdNumericDatatype.fromString("xsd:int");
+    assertEquals(XsdNumericDatatype.INTEGER, result,
+      "Expected INTEGER (first declared); got " + result + ". "
+        + "If you reordered the enum, search for `XsdNumericDatatype.fromString(\"xsd:int\")` "
+        + "usages and verify they still expect INTEGER.");
+  }
+
+  @Test public void testFieldInstanceCreateAcceptsEmptyJsonLdTypes()
+  {
+    // Normal usage: a literal field instance has no JSON-LD @type. The create factory must
+    // accept an empty list, not throw.
+    FieldInstanceArtifact instance = FieldInstanceArtifact.create(
+      Collections.emptyList(), Optional.empty(),
+      Optional.of("hello"), Optional.empty(), Optional.empty(),
+      Optional.empty(), Optional.empty());
+
+    assertNotNull(instance);
+    assertTrue(instance.jsonLdTypes().isEmpty());
+    assertEquals("hello", instance.jsonLdValue().get());
+  }
+
+  @Test public void testStatusFromStringRejectsUnknown()
+  {
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+      () -> Status.fromString("limbo"));
+    assertTrue(ex.getMessage().contains("limbo"));
+  }
+}

--- a/src/test/java/org/metadatacenter/artifacts/model/core/VisitorDepthTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/VisitorDepthTest.java
@@ -1,0 +1,145 @@
+package org.metadatacenter.artifacts.model.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Group G — Visitor pattern depth. Existing tests cover the single-template happy path; this
+ * batch pins the contract for deeply nested templates and multi-instance children, which are
+ * the harder paths consumers actually rely on (e.g., REDCap export, terminology lookups).
+ */
+public class VisitorDepthTest
+{
+  private static FieldInstanceArtifact literal(String value)
+  {
+    return FieldInstanceArtifact.create(java.util.Collections.emptyList(), Optional.empty(),
+      Optional.of(value), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  @Test public void testSchemaVisitorVisitsDeeplyNestedChildren()
+  {
+    // template -> outerElement -> innerElement -> textField
+    TextField leaf = TextField.builder().withName("leaf").build();
+    ElementSchemaArtifact inner = ElementSchemaArtifact.builder()
+      .withName("inner").withFieldSchema(leaf).build();
+    ElementSchemaArtifact outer = ElementSchemaArtifact.builder()
+      .withName("outer").withElementSchema(inner).build();
+    TemplateSchemaArtifact template = TemplateSchemaArtifact.builder()
+      .withName("T").withElementSchema(outer).build();
+
+    SchemaReporter reporter = new SchemaReporter();
+    template.accept(reporter);
+
+    // Visitor must reach every level — 1 template + 2 elements + 1 field = 4 names.
+    assertEquals(4, reporter.names.size());
+    assertTrue(reporter.names.contains("T"));
+    assertTrue(reporter.names.contains("outer"));
+    assertTrue(reporter.names.contains("inner"));
+    assertTrue(reporter.names.contains("leaf"));
+  }
+
+  @Test public void testSchemaVisitorVisitsInDocumentOrder()
+  {
+    // The visit order should follow childKeys insertion order, not alphabetical.
+    TextField a = TextField.builder().withName("alpha").build();
+    TextField b = TextField.builder().withName("zulu").build();
+    TextField c = TextField.builder().withName("mike").build();
+
+    TemplateSchemaArtifact template = TemplateSchemaArtifact.builder().withName("T")
+      .withFieldSchema(b).withFieldSchema(c).withFieldSchema(a).build();
+
+    SchemaReporter reporter = new SchemaReporter();
+    template.accept(reporter);
+
+    // First name is the template, then children in insertion order.
+    assertEquals("T", reporter.names.get(0));
+    assertEquals("zulu", reporter.names.get(1));
+    assertEquals("mike", reporter.names.get(2));
+    assertEquals("alpha", reporter.names.get(3));
+  }
+
+  @Test public void testInstanceVisitorVisitsMultiInstanceFieldElements()
+  {
+    FieldInstanceArtifact a = literal("first");
+    FieldInstanceArtifact b = literal("second");
+    FieldInstanceArtifact c = literal("third");
+
+    TemplateInstanceArtifact instance = TemplateInstanceArtifact.builder().withName("Inst")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withMultiInstanceFieldInstances("keywords", List.of(a, b, c))
+      .build();
+
+    InstanceReporter reporter = new InstanceReporter();
+    instance.accept(reporter);
+
+    // 1 template + 3 multi-instance field entries
+    assertEquals(4, reporter.paths.size());
+    // Multi-instance paths are indexed.
+    assertTrue(reporter.paths.stream().anyMatch(p -> p.contains("keywords")),
+      "Expected keywords path; got " + reporter.paths);
+  }
+
+  @Test public void testInstanceVisitorFiresAttributeValueHookPerEntry()
+  {
+    // visitAttributeValueFieldInstanceArtifact must fire once per entry in the group, not once
+    // per group. This is the contract `InstanceReporter` relies on for spec-path lookups.
+    LinkedHashMap<String, FieldInstanceArtifact> group = new LinkedHashMap<>();
+    group.put("attr1", literal("a"));
+    group.put("attr2", literal("b"));
+    group.put("attr3", literal("c"));
+
+    TemplateInstanceArtifact instance = TemplateInstanceArtifact.builder().withName("Inst")
+      .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
+      .withAttributeValueFieldGroup("custom", group).build();
+
+    AvCountingReporter reporter = new AvCountingReporter();
+    instance.accept(reporter);
+
+    assertEquals(3, reporter.attrCalls);
+  }
+
+  // ---- visitor implementations ----
+
+  private static class SchemaReporter implements SchemaArtifactVisitor
+  {
+    final List<String> names = new ArrayList<>();
+
+    @Override public void visitTemplateSchemaArtifact(TemplateSchemaArtifact t) { names.add(t.name()); }
+    @Override public void visitElementSchemaArtifact(ElementSchemaArtifact e, String p) { names.add(e.name()); }
+    @Override public void visitFieldSchemaArtifact(FieldSchemaArtifact f, String p) { names.add(f.name()); }
+  }
+
+  private static class InstanceReporter implements InstanceArtifactVisitor
+  {
+    final List<String> paths = new ArrayList<>();
+
+    @Override public void visitTemplateInstanceArtifact(TemplateInstanceArtifact t) { paths.add("/"); }
+    @Override public void visitElementInstanceArtifact(ElementInstanceArtifact e, String p) { paths.add(p); }
+    @Override public void visitFieldInstanceArtifact(FieldInstanceArtifact f, String p) { paths.add(p); }
+    @Override public void visitAttributeValueFieldInstanceArtifact(FieldInstanceArtifact f, String p, String sp)
+    {
+      paths.add(p);
+    }
+  }
+
+  private static class AvCountingReporter implements InstanceArtifactVisitor
+  {
+    int attrCalls = 0;
+
+    @Override public void visitTemplateInstanceArtifact(TemplateInstanceArtifact t) {}
+    @Override public void visitElementInstanceArtifact(ElementInstanceArtifact e, String p) {}
+    @Override public void visitFieldInstanceArtifact(FieldInstanceArtifact f, String p) {}
+    @Override public void visitAttributeValueFieldInstanceArtifact(FieldInstanceArtifact f, String p, String sp)
+    {
+      attrCalls++;
+    }
+  }
+}

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ui/NumericFieldUiTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ui/NumericFieldUiTest.java
@@ -25,4 +25,30 @@ public class NumericFieldUiTest
     assertEquals(continuePreviousLine, numericFieldUi.continuePreviousLine());
   }
 
+  @Test
+  public void testHiddenAndContinuePreviousLineSetters()
+  {
+    NumericFieldUi ui = NumericFieldUi.builder()
+      .withHidden(true)
+      .withContinuePreviousLine(true)
+      .build();
+
+    assertTrue(ui.hidden());
+    assertTrue(ui.continuePreviousLine());
+  }
+
+  @Test
+  public void testCopyBuilderPreservesSettings()
+  {
+    NumericFieldUi original = NumericFieldUi.builder()
+      .withHidden(true)
+      .withContinuePreviousLine(true)
+      .build();
+
+    NumericFieldUi copy = NumericFieldUi.builder(original).build();
+
+    assertEquals(original.hidden(), copy.hidden());
+    assertEquals(original.continuePreviousLine(), copy.continuePreviousLine());
+    assertEquals(original.inputType(), copy.inputType());
+  }
 }

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ui/TemporalFieldUiTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ui/TemporalFieldUiTest.java
@@ -35,4 +35,43 @@ public class TemporalFieldUiTest
     assertEquals(continuePreviousLine, temporalFieldUi.continuePreviousLine());
   }
 
+  @Test
+  public void testAllTemporalGranularities()
+  {
+    // Each TemporalGranularity must round-trip the builder without coercion. The renderer
+    // emits granularity-conditional fields based on whether the granularity isYear/isMonth/isDay,
+    // so the builder must preserve the exact constant.
+    for (TemporalGranularity g : TemporalGranularity.values()) {
+      TemporalFieldUi ui = TemporalFieldUi.builder()
+        .withTemporalGranularity(g)
+        .withInputTimeFormat(InputTimeFormat.TWENTY_FOUR_HOUR)
+        .build();
+      assertEquals(g, ui.temporalGranularity());
+    }
+  }
+
+  @Test
+  public void testInputTimeFormatTwelveHour()
+  {
+    TemporalFieldUi ui = TemporalFieldUi.builder()
+      .withTemporalGranularity(TemporalGranularity.MINUTE)
+      .withInputTimeFormat(InputTimeFormat.TWELVE_HOUR)
+      .build();
+
+    assertEquals(InputTimeFormat.TWELVE_HOUR, ui.inputTimeFormat().get());
+  }
+
+  @Test
+  public void testTimezoneEnabledExplicitlyTrue()
+  {
+    // Default is Optional.empty(); setting true must surface as Optional.of(true).
+    TemporalFieldUi ui = TemporalFieldUi.builder()
+      .withTemporalGranularity(TemporalGranularity.MINUTE)
+      .withInputTimeFormat(InputTimeFormat.TWENTY_FOUR_HOUR)
+      .withTimezoneEnabled(true)
+      .build();
+
+    assertTrue(ui.timezoneEnabled().isPresent());
+    assertTrue(ui.timezoneEnabled().get());
+  }
 }

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/ArtifactParseExceptionTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/ArtifactParseExceptionTest.java
@@ -1,0 +1,40 @@
+package org.metadatacenter.artifacts.model.reader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Group B — ArtifactParseException carries fieldKey + path that consumers parse for error
+ * display. These tests pin the contract so refactors don't quietly drop the context.
+ */
+public class ArtifactParseExceptionTest
+{
+  @Test public void testPreservesFieldKey()
+  {
+    ArtifactParseException ex = new ArtifactParseException("bad value", "schema:name", "/template/foo");
+    assertEquals("schema:name", ex.getFieldKey());
+  }
+
+  @Test public void testPreservesPath()
+  {
+    ArtifactParseException ex = new ArtifactParseException("bad value", "schema:name", "/template/foo");
+    assertEquals("/template/foo", ex.getPath());
+  }
+
+  @Test public void testMessageContainsBothFieldKeyAndPath()
+  {
+    // Consumers display ex.getMessage() to humans; both the offending field name and the path
+    // to it must appear so the message is actionable.
+    ArtifactParseException ex = new ArtifactParseException("bad value", "schema:name", "/template/foo");
+    assertTrue(ex.getMessage().contains("schema:name"),
+      "exception message missing field key. Got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("/template/foo"),
+      "exception message missing path. Got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("bad value"),
+      "exception message missing root cause. Got: " + ex.getMessage());
+    // And the raw parse-error message is recoverable separately.
+    assertEquals("bad value", ex.getParseErrorMessage());
+  }
+}

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/JsonArtifactReaderNegativePathsTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/JsonArtifactReaderNegativePathsTest.java
@@ -1,0 +1,243 @@
+package org.metadatacenter.artifacts.model.reader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.metadatacenter.model.ModelNodeNames.ELEMENT_SCHEMA_ARTIFACT_TYPE_IRI;
+import static org.metadatacenter.model.ModelNodeNames.FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
+import static org.metadatacenter.model.ModelNodeNames.FIELD_SCHEMA_ARTIFACT_TYPE_IRI;
+import static org.metadatacenter.model.ModelNodeNames.JSON_LD_CONTEXT;
+import static org.metadatacenter.model.ModelNodeNames.JSON_LD_TYPE;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_ADDITIONAL_PROPERTIES;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_DESCRIPTION;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_OBJECT;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_PROPERTIES;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_SCHEMA;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_SCHEMA_IRI;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_TITLE;
+import static org.metadatacenter.model.ModelNodeNames.JSON_SCHEMA_TYPE;
+import static org.metadatacenter.model.ModelNodeNames.PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS;
+import static org.metadatacenter.model.ModelNodeNames.PAV_VERSION;
+import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_DESCRIPTION;
+import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_NAME;
+import static org.metadatacenter.model.ModelNodeNames.SCHEMA_ORG_SCHEMA_VERSION;
+import static org.metadatacenter.model.ModelNodeNames.TEMPLATE_SCHEMA_ARTIFACT_TYPE_IRI;
+import static org.metadatacenter.model.ModelNodeNames.UI;
+
+/**
+ * Group A — JsonArtifactReader negative paths. The existing JsonArtifactReaderTest is all
+ * happy-path fixture loads; these tests cover the 25 throw sites in the reader to ensure
+ * malformed input fails fast with useful exceptions instead of producing silently-wrong
+ * artifacts.
+ */
+public class JsonArtifactReaderNegativePathsTest
+{
+  private JsonArtifactReader reader;
+  private ObjectMapper mapper;
+
+  @BeforeEach public void setup()
+  {
+    reader = new JsonArtifactReader();
+    mapper = new ObjectMapper();
+  }
+
+  // ---- @type checks ----
+
+  @Test public void testReadTemplateThrowsOnMissingJsonLdType()
+  {
+    ObjectNode node = baseTemplate("T", "d");
+    node.remove(JSON_LD_TYPE);
+
+    assertThrows(ArtifactParseException.class, () -> reader.readTemplateSchemaArtifact(node));
+  }
+
+  @Test public void testReadTemplateThrowsOnWrongJsonLdType()
+  {
+    // A template document tagged with the element IRI should be rejected — silently accepting
+    // would let consumers cast Element→Template downstream and explode.
+    ObjectNode node = baseTemplate("T", "d");
+    node.put(JSON_LD_TYPE, ELEMENT_SCHEMA_ARTIFACT_TYPE_IRI);
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> reader.readTemplateSchemaArtifact(node));
+    assertTrue(ex.getMessage().contains("template"));
+  }
+
+  @Test public void testReadFieldThrowsOnMissingSchemaName()
+  {
+    ObjectNode node = baseField("Test", "d");
+    node.remove(SCHEMA_ORG_NAME);
+
+    assertThrows(ArtifactParseException.class, () -> reader.readFieldSchemaArtifact(node));
+  }
+
+  @Test public void testReadFieldThrowsOnMalformedVersion()
+  {
+    // Parallels JsonNodeReaders.readVersion contract (PR #43) — through the public API.
+    ObjectNode node = baseField("Test", "d");
+    node.put(PAV_VERSION, "not-a-version");
+    node.with(UI).put("inputType", "textfield");
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> reader.readFieldSchemaArtifact(node));
+    assertTrue(ex.getMessage().contains("not-a-version"));
+  }
+
+  @Test public void testReadTemplateInstanceThrowsOnMissingIsBasedOn()
+  {
+    // A template-instance with no isBasedOn is unparseable — we'd have nothing to validate
+    // the instance against.
+    ObjectNode node = mapper.createObjectNode();
+    node.put(JSON_LD_TYPE, mapper.createArrayNode());
+    node.put(SCHEMA_ORG_NAME, "Inst");
+    node.put(SCHEMA_ORG_DESCRIPTION, "d");
+
+    assertThrows(Exception.class, () -> reader.readTemplateInstanceArtifact(node));
+  }
+
+  @Test public void testReadElementThrowsOnMissingProperties()
+  {
+    // Element schemas need a `properties` block for nested children.
+    ObjectNode node = baseElement("E", "d");
+    node.remove(JSON_SCHEMA_PROPERTIES);
+
+    assertThrows(ArtifactParseException.class, () -> reader.readElementSchemaArtifact(node));
+  }
+
+  // ---- JsonNodeReaders helper rejections ----
+
+  @Test public void testReadUriRejectsNonStringNode()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put("uri", 42);
+
+    assertThrows(Exception.class, () -> JsonNodeReaders.readUri(node, "/", "uri"));
+  }
+
+  @Test public void testReadIntegerRejectsStringFormattedNumber()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put("n", "42");
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> JsonNodeReaders.readInteger(node, "/", "n"));
+    assertTrue(ex.getMessage().contains("integer"));
+  }
+
+  @Test public void testReadBooleanRejectsStringTrue()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put("flag", "true");
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> JsonNodeReaders.readBoolean(node, "/", "flag", false));
+    assertTrue(ex.getMessage().contains("boolean"));
+  }
+
+  @Test public void testReadOffsetDateTimeRejectsMalformedString()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put("ts", "not-a-date");
+
+    assertThrows(Exception.class, () -> JsonNodeReaders.readOffsetDateTime(node, "/", "ts"));
+  }
+
+  // ---- Group I: JSON shape robustness ----
+
+  @Test public void testReadTemplateThrowsOnArrayProperties()
+  {
+    // The JSON Schema `properties` value must be an object. An array (or any non-object)
+    // is malformed.
+    ObjectNode node = baseTemplate("T", "d");
+    node.set(JSON_SCHEMA_PROPERTIES, mapper.createArrayNode());
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> reader.readTemplateSchemaArtifact(node));
+    assertTrue(ex.getMessage().toLowerCase().contains("properties"));
+  }
+
+  @Test public void testReadFieldThrowsOnUnknownInputType()
+  {
+    ObjectNode node = baseField("Test", "d");
+    node.with(UI).put("inputType", "not-a-real-input-type");
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> reader.readFieldSchemaArtifact(node));
+    assertTrue(ex.getMessage().contains("not-a-real-input-type"));
+  }
+
+  @Test public void testReadFieldThrowsOnMissingUi()
+  {
+    // The `_ui` block is required on every field schema; its absence is malformed.
+    ObjectNode node = baseField("Test", "d");
+    node.remove(UI);
+
+    assertThrows(Exception.class, () -> reader.readFieldSchemaArtifact(node));
+  }
+
+  @Test public void testReadTemplateThrowsOnWrongJsonSchemaType()
+  {
+    // The top-level `type` JSON-Schema key must be `object`; rejecting `array` keeps the
+    // reader from accepting documents that look superficially right.
+    ObjectNode node = baseTemplate("T", "d");
+    node.put(JSON_SCHEMA_TYPE, "array");
+
+    assertThrows(ArtifactParseException.class, () -> reader.readTemplateSchemaArtifact(node));
+  }
+
+  // ---- Helpers ----
+
+  private ObjectNode baseTemplate(String name, String description)
+  {
+    ObjectNode node = baseSchema(name, description);
+    node.put(JSON_LD_CONTEXT, createContextMap(PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS));
+    node.put(JSON_LD_TYPE, TEMPLATE_SCHEMA_ARTIFACT_TYPE_IRI);
+    return node;
+  }
+
+  private ObjectNode baseElement(String name, String description)
+  {
+    ObjectNode node = baseSchema(name, description);
+    node.put(JSON_LD_CONTEXT, createContextMap(PARENT_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS));
+    node.put(JSON_LD_TYPE, ELEMENT_SCHEMA_ARTIFACT_TYPE_IRI);
+    return node;
+  }
+
+  private ObjectNode baseField(String name, String description)
+  {
+    ObjectNode node = baseSchema(name, description);
+    node.put(JSON_LD_CONTEXT, createContextMap(FIELD_SCHEMA_ARTIFACT_CONTEXT_PREFIX_MAPPINGS));
+    node.put(JSON_LD_TYPE, FIELD_SCHEMA_ARTIFACT_TYPE_IRI);
+    return node;
+  }
+
+  private ObjectNode baseSchema(String name, String description)
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put(SCHEMA_ORG_SCHEMA_VERSION, "1.6.0");
+    node.put(SCHEMA_ORG_NAME, name);
+    node.put(SCHEMA_ORG_DESCRIPTION, description);
+    node.put(JSON_SCHEMA_SCHEMA, JSON_SCHEMA_SCHEMA_IRI);
+    node.put(JSON_SCHEMA_TYPE, JSON_SCHEMA_OBJECT);
+    node.put(JSON_SCHEMA_TITLE, "title");
+    node.put(JSON_SCHEMA_DESCRIPTION, "desc");
+    node.put(JSON_SCHEMA_PROPERTIES, mapper.createObjectNode());
+    node.put(JSON_SCHEMA_ADDITIONAL_PROPERTIES, false);
+    node.put(UI, mapper.createObjectNode());
+    return node;
+  }
+
+  private ObjectNode createContextMap(Map<String, java.net.URI> contextMap)
+  {
+    ObjectNode node = mapper.createObjectNode();
+    for (var e : contextMap.entrySet())
+      node.put(e.getKey(), e.getValue().toString());
+    return node;
+  }
+}

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/JsonValueConstraintsReaderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/JsonValueConstraintsReaderTest.java
@@ -1,0 +1,142 @@
+package org.metadatacenter.artifacts.model.reader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.metadatacenter.artifacts.model.core.fields.constraints.BranchValueConstraint;
+import org.metadatacenter.artifacts.model.core.fields.constraints.ClassValueConstraint;
+import org.metadatacenter.artifacts.model.core.fields.constraints.ControlledTermValueConstraintsAction;
+import org.metadatacenter.artifacts.model.core.fields.constraints.OntologyValueConstraint;
+import org.metadatacenter.artifacts.model.core.fields.constraints.ValueConstraintsActionType;
+import org.metadatacenter.artifacts.model.core.fields.constraints.ValueSetValueConstraint;
+import org.metadatacenter.artifacts.model.core.fields.constraints.ValueType;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Group C — JsonValueConstraintsReader has 401 LOC and zero direct tests. Value constraints
+ * control field validation, so silent bugs here mean fields validate the wrong things.
+ */
+public class JsonValueConstraintsReaderTest
+{
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  // VALUE_CONSTRAINTS_* keys are all literal strings under JSON Schema; using literals here
+  // keeps the test focused on shape rather than constants.
+
+  @Test public void testReadOntologyValueConstraint()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put("uri", "https://data.bioontology.org/ontologies/DOID");
+    node.put("acronym", "DOID");
+    node.put("name", "Human Disease Ontology");
+    node.put("numTerms", 15000);
+
+    OntologyValueConstraint result = JsonValueConstraintsReader.readOntologyValueConstraint(node, "/");
+
+    assertEquals(URI.create("https://data.bioontology.org/ontologies/DOID"), result.uri());
+    assertEquals("DOID", result.acronym());
+    assertEquals("Human Disease Ontology", result.name());
+    assertEquals(15000, result.numTerms().get());
+  }
+
+  @Test public void testReadOntologyValueConstraintsArray()
+  {
+    ObjectNode parent = mapper.createObjectNode();
+    ArrayNode arr = parent.putArray("ontologies");
+    ObjectNode entry = arr.addObject();
+    entry.put("uri", "https://example.com/ont/1");
+    entry.put("acronym", "ONT1");
+    entry.put("name", "Test Ontology");
+
+    List<OntologyValueConstraint> results =
+      JsonValueConstraintsReader.readOntologyValueConstraints(parent, "/", "ontologies");
+
+    assertEquals(1, results.size());
+    assertEquals("ONT1", results.get(0).acronym());
+
+    // Non-array value: returns empty (silently — documenting the contract).
+    ObjectNode notArray = mapper.createObjectNode();
+    notArray.put("ontologies", "not an array");
+    assertTrue(
+      JsonValueConstraintsReader.readOntologyValueConstraints(notArray, "/", "ontologies").isEmpty());
+  }
+
+  @Test public void testReadClassValueConstraint()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put("uri", "http://purl.bioontology.org/ontology/LNC/LA19711-3");
+    node.put("source", "LOINC");
+    node.put("label", "Homo Sapiens");
+    node.put("prefLabel", "Homo Sapiens");
+    node.put("type", ValueType.ONTOLOGY_CLASS.getText());
+
+    ClassValueConstraint result = JsonValueConstraintsReader.readClassValueConstraint(node, "/");
+
+    assertEquals("LOINC", result.source());
+    assertEquals("Homo Sapiens", result.label());
+    assertEquals(ValueType.ONTOLOGY_CLASS, result.type());
+  }
+
+  @Test public void testReadValueSetValueConstraint()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put("uri", "https://purl.humanatlas.io/vocab/hravs#HRAVS_1000161");
+    node.put("name", "Area unit");
+    node.put("vsCollection", "HRAVS");
+    node.put("numTerms", 40);
+
+    ValueSetValueConstraint result = JsonValueConstraintsReader.readValueSetValueConstraint(node, "/");
+
+    assertEquals("HRAVS", result.vsCollection());
+    assertEquals("Area unit", result.name());
+    assertEquals(40, result.numTerms().get());
+  }
+
+  @Test public void testReadBranchValueConstraint()
+  {
+    ObjectNode node = mapper.createObjectNode();
+    node.put("uri", "http://purl.org/twc/dpo/ont/Disease");
+    node.put("source", "DPCO");
+    node.put("acronym", "DPCO");
+    node.put("name", "Disease");
+    node.put("maxDepth", 3);
+
+    BranchValueConstraint result = JsonValueConstraintsReader.readBranchValueConstraint(node, "/");
+
+    assertEquals("DPCO", result.source());
+    assertEquals(3, result.maxDepth());
+  }
+
+  @Test public void testReadValueConstraintsActionFullShape()
+  {
+    // The action shape carries all fields; absence of the array node returns empty.
+    ObjectNode action = mapper.createObjectNode();
+    action.put("termUri", "https://purl.org/datacite/v4.4/TranslatedTitle");
+    action.put("sourceUri", "https://purl.org/datacite/v4.4/TitleType");
+    action.put("source", "DATACITE-VOCAB");
+    action.put("type", ValueType.ONTOLOGY_CLASS.getText());
+    action.put("action", ValueConstraintsActionType.DELETE.getText());
+    action.put("to", 5);
+
+    ControlledTermValueConstraintsAction result =
+      JsonValueConstraintsReader.readValueConstraintsAction(action, "/");
+
+    assertEquals(URI.create("https://purl.org/datacite/v4.4/TranslatedTitle"), result.termUri());
+    assertEquals(ValueConstraintsActionType.DELETE, result.action());
+    assertEquals(5, result.to().get());
+
+    // And the array-reading helper bubbles up an exception on non-object entries.
+    ObjectNode parent = mapper.createObjectNode();
+    ArrayNode arr = parent.putArray("actions");
+    arr.add("not-an-object");
+    assertThrows(ArtifactParseException.class,
+      () -> JsonValueConstraintsReader.readValueConstraintsActions(parent, "/", "actions"));
+  }
+}

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReaderNegativePathsTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReaderNegativePathsTest.java
@@ -1,0 +1,102 @@
+package org.metadatacenter.artifacts.model.reader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Group D — YAML reader negative paths. The reader has well-defined throws at boundaries
+ * (children must be a list, child entries must be maps, types must be known) that no test
+ * exercised. Hand-authored YAML is common so these messages have to surface useful errors.
+ */
+public class YamlArtifactReaderNegativePathsTest
+{
+  private YamlArtifactReader reader;
+
+  @BeforeEach public void setup()
+  {
+    reader = new YamlArtifactReader();
+  }
+
+  private LinkedHashMap<String, Object> minimalTemplate()
+  {
+    LinkedHashMap<String, Object> node = new LinkedHashMap<>();
+    node.put("type", "template");
+    node.put("name", "T");
+    // YamlArtifactReader requires `modelVersion: 1.6.0` to pass its top-level shape check.
+    node.put("modelVersion", "1.6.0");
+    return node;
+  }
+
+  @Test public void testReadChildSchemasRejectsMapInsteadOfList()
+  {
+    // `children:` must be a LIST of child maps; a top-level Map under `children:` is illegal.
+    LinkedHashMap<String, Object> node = minimalTemplate();
+    LinkedHashMap<String, Object> kids = new LinkedHashMap<>();
+    kids.put("foo", new LinkedHashMap<>());
+    node.put("children", kids);
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> reader.readTemplateSchemaArtifact(node));
+    assertTrue(ex.getMessage().toLowerCase().contains("list"));
+  }
+
+  @Test public void testReadChildSchemasRejectsNonMapEntryInList()
+  {
+    LinkedHashMap<String, Object> node = minimalTemplate();
+    node.put("children", new ArrayList<>(Arrays.asList("a string, not a map")));
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> reader.readTemplateSchemaArtifact(node));
+    assertTrue(ex.getMessage().toLowerCase().contains("map"));
+  }
+
+  @Test public void testReadChildSchemasRejectsUnknownChildType()
+  {
+    LinkedHashMap<String, Object> child = new LinkedHashMap<>();
+    child.put("key", "x");
+    child.put("type", "not-a-real-type");
+    child.put("name", "X");
+
+    LinkedHashMap<String, Object> node = minimalTemplate();
+    node.put("children", new ArrayList<>(Arrays.asList(child)));
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> reader.readTemplateSchemaArtifact(node));
+    assertTrue(ex.getMessage().contains("not-a-real-type"),
+      "Expected exception to mention the unknown type. Got: " + ex.getMessage());
+  }
+
+  @Test public void testReadTemplateRejectsWrongTopLevelType()
+  {
+    LinkedHashMap<String, Object> node = new LinkedHashMap<>();
+    node.put("type", "element");
+    node.put("name", "X");
+    node.put("modelVersion", "1.6.0");
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> reader.readTemplateSchemaArtifact(node));
+    assertTrue(ex.getMessage().contains("template"));
+  }
+
+  @Test public void testReadVersionRejectsInvalidString()
+  {
+    // Mirrors the JSON readVersion contract (PR #43) on the YAML side. A field with an
+    // invalid `version:` must surface a parse error, not silently coerce.
+    LinkedHashMap<String, Object> field = new LinkedHashMap<>();
+    field.put("type", "text-field");
+    field.put("name", "X");
+    field.put("modelVersion", "1.6.0");
+    field.put("version", "garbage");
+
+    ArtifactParseException ex = assertThrows(ArtifactParseException.class,
+      () -> reader.readFieldSchemaArtifact(field));
+    assertTrue(ex.getMessage().contains("garbage"));
+  }
+}


### PR DESCRIPTION
## Summary
A second test batch focused on bug-catching gaps the builder batch missed. Two of the asymmetry probes caught **real silent-data-loss bugs** and are checked in as `@Disabled` with regression notes; follow-up fix tasks have been spawned.

### Coverage by group
| Group | Tests | Catches |
|------|------:|---|
| A. JsonArtifactReader negative paths | 10 | 25 throw sites had zero coverage |
| B. ArtifactParseException context | 3 | Consumers parse fieldKey/path from message |
| C. JsonValueConstraintsReader unit tests | 6 | 401 LOC previously untested |
| D. YAML reader negative paths | 5 | readChildSchemas + version + wrong type |
| E. **Renderer asymmetry probes** | 5 (2 disabled) | **Found 2 real bugs** ↓ |
| F. UI sub-builders | 5 | NumericFieldUi / TemporalFieldUi copy-builder + granularity sweep |
| G. Visitor pattern depth | 4 | Deep nesting + document order + multi-instance + attribute-value hook |
| H+L. Core contract pinning | 3 | XsdNumericDatatype INT/INTEGER + empty types + Status.fromString |
| I. JSON shape robustness | 4 | Array properties, unknown inputType, missing UI, wrong jsonSchema type |
| J. Attribute-value JSON round-trip | 3 | Group name + entry order + empty-group safety |
| K. Annotations equality/order | 2 | Equality is order-insensitive; renderer preserves order |
| **Total** | **50** | **404 suite (was 354), 0 failures, 2 disabled** |

### Bugs caught and filed
The Group E asymmetry probes flushed out two real bugs in the YAML renderer/reader pair:

1. **YAML round-trip silently drops `width:`/`height:`** on YouTube/image static fields. Test: `YamlAsymmetryProbeTest.testRoundTripPreservesYouTubeWidthHeight` (currently `@Disabled`).
2. **YAML round-trip silently drops `valueRecommendation:`** on controlled-term fields. Test: `YamlAsymmetryProbeTest.testRoundTripPreservesValueRecommendationOnControlledTerm` (currently `@Disabled`).

Both regression tests are in place — remove the `@Disabled` annotations when the underlying bugs are fixed. Spawn tasks were filed for both.

### Test plan
- [x] `mvn test` — 404 passing (50 new), 0 failures, 2 skipped (the captured-bug regressions)
- [x] `mvn spotless:check` — clean
- [ ] Reviewer eyeballs the Group E disabled tests and the spawn-task descriptions for completeness

### Notable highlights
- Group E found bugs in code paths the existing 113-test JSON round-trip suite didn't exercise.
- Group I + D cover the *boundary* — bad data entering the system — where the project had near-zero coverage before this batch.
- Group J's `testJsonRoundTripPreservesAttributeValueEntryOrder` is the only explicit test for attribute-value entry ordering, which the JSON renderer encodes via a sibling array-of-names structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)