### PR TITLE
Strip process-referencing comments from test files

### DIFF
--- a/src/test/java/org/metadatacenter/artifacts/model/AnnotationsEqualityAndOrderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/AnnotationsEqualityAndOrderTest.java
@@ -13,11 +13,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * Group K — Annotations equality and JSON round-trip ordering. Annotations is a record
- * around a LinkedHashMap; the equality semantics and the JSON renderer's ordering both
- * deserve explicit pinning.
- */
 public class AnnotationsEqualityAndOrderTest
 {
   private JsonArtifactReader reader;
@@ -31,10 +26,8 @@ public class AnnotationsEqualityAndOrderTest
 
   @Test public void testAnnotationsEqualityIgnoresInsertionOrder()
   {
-    // Annotations is a record wrapping a LinkedHashMap; LinkedHashMap.equals checks
-    // entry-by-entry without regard to insertion order. Pin this contract — if someone
-    // refactors equality to be order-sensitive, downstream callers that compare annotations
-    // built in different orders would silently break.
+    // Annotations wraps a LinkedHashMap; LinkedHashMap.equals is entry-by-entry without
+    // regard to insertion order.
     Annotations a = Annotations.builder()
       .withLiteralAnnotation("x", "1")
       .withLiteralAnnotation("y", "2")
@@ -50,9 +43,7 @@ public class AnnotationsEqualityAndOrderTest
 
   @Test public void testJsonRoundTripPreservesAnnotationInsertionOrder()
   {
-    // Even though equality is order-insensitive, the renderer's *output* should be ordered
-    // (so YAML/JSON files have stable diffs). Verify the round-tripped Annotations preserves
-    // the original insertion order.
+    // Renderer output is ordered so YAML/JSON files have stable diffs.
     Annotations annotations = Annotations.builder()
       .withLiteralAnnotation("z", "1")
       .withLiteralAnnotation("a", "2")

--- a/src/test/java/org/metadatacenter/artifacts/model/JsonAttributeValueRoundTripTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/JsonAttributeValueRoundTripTest.java
@@ -19,11 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Group J — focused JSON round-trip tests for attribute-value field groups. Existing
- * JsonArtifactRoundTripTest covers attribute-value via fixture files but asserts on the
- * whole artifact's equality — these tests pin the specific contract on
- * {@code attributeValueFieldInstanceGroups()} so a regression in the JSON shape (the
- * "array of names + sibling single instances" form) doesn't slip past.
+ * Focused JSON round-trip tests for attribute-value field groups. Pins the
+ * {@link TemplateInstanceArtifact#attributeValueFieldInstanceGroups()} contract against
+ * regressions in the JSON shape (array of names + sibling single instances).
  */
 public class JsonAttributeValueRoundTripTest
 {
@@ -66,8 +64,7 @@ public class JsonAttributeValueRoundTripTest
 
   @Test public void testJsonRoundTripPreservesAttributeValueEntryOrder()
   {
-    // The renderer serializes via an array of names + sibling single instances; entry order
-    // must survive the round-trip (UI consumers display fields in this order).
+    // UI consumers display attribute-value fields in builder order.
     LinkedHashMap<String, FieldInstanceArtifact> group = new LinkedHashMap<>();
     group.put("z-attr", literal("3"));
     group.put("a-attr", literal("1"));
@@ -87,9 +84,8 @@ public class JsonAttributeValueRoundTripTest
 
   @Test public void testJsonRoundTripWithEmptyAttributeValueGroupRendersWithoutError()
   {
-    // Empty group is a degenerate case — the renderer's behavior here defines whether such
-    // a group survives at all. We don't assert it's preserved; we just pin that the round-trip
-    // doesn't throw, so consumers can pass through these instances safely.
+    // The empty-group case isn't required to survive (renderer may drop it), but the
+    // round-trip must not throw.
     TemplateInstanceArtifact original = TemplateInstanceArtifact.builder().withName("Inst")
       .withIsBasedOn(URI.create("https://repo.metadatacenter.org/templates/abc"))
       .withAttributeValueFieldGroup("empty", new LinkedHashMap<>())
@@ -98,8 +94,6 @@ public class JsonAttributeValueRoundTripTest
     ObjectNode json = renderer.renderTemplateInstanceArtifact(original);
     TemplateInstanceArtifact roundTripped = reader.readTemplateInstanceArtifact(json);
 
-    // Either the group survives (empty) or it gets dropped — both are acceptable; we just
-    // want the round-trip itself not to throw.
     assertEquals("Inst", roundTripped.name().get());
   }
 }

--- a/src/test/java/org/metadatacenter/artifacts/model/YamlAsymmetryProbeTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/YamlAsymmetryProbeTest.java
@@ -22,9 +22,8 @@ import java.util.LinkedHashMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Group E — round-trip *probes* targeted at fields the Explore survey flagged as potentially
- * being silently dropped by the YAML renderer / reader pair. If these tests pass, we confirm
- * symmetry; if they ever fail, we found a real silent-data-loss bug.
+ * Round-trip probes for individual field settings that the YAML renderer / reader pair has
+ * historically dropped. A failure here means a silent-data-loss bug in the YAML pipeline.
  */
 public class YamlAsymmetryProbeTest
 {
@@ -37,10 +36,9 @@ public class YamlAsymmetryProbeTest
     renderer = new YamlArtifactRenderer(false);
   }
 
-  // Captured as part of this PR: the renderer emits width/height but the reader doesn't
-  // wire them through for static fields. Disabled until the asymmetry is fixed; re-enable
-  // when YamlArtifactReader.readFieldUi handles static-field width/height.
-  @Disabled("Round-trip silently drops width/height on YouTube/Image fields — separate fix")
+  // Known bug: YamlArtifactReader.readFieldUi doesn't wire width/height through when
+  // constructing a StaticFieldUi, so the round-trip silently drops them.
+  @Disabled("YAML round-trip drops width/height on YouTube/Image fields")
   @Test public void testRoundTripPreservesYouTubeWidthHeight()
   {
     // Width/height live on YouTubeFieldUiBuilder; the field builder itself doesn't expose them.
@@ -55,14 +53,12 @@ public class YamlAsymmetryProbeTest
     assertEquals(480, roundTripped.fieldUi().asStaticFieldUi().height().get());
   }
 
-  // Captured as part of this PR: the renderer emits `valueRecommendation:` when the field UI
-  // flag is true, but the round-tripped artifact comes back with the flag false. The reader's
-  // readFieldUi reads VALUE_RECOMMENDATION at the field level, but the renderer emits it under
-  // the controlled-term values block (or vice versa). Disabled until the location agrees.
-  @Disabled("Round-trip silently drops valueRecommendation flag — separate fix")
+  // Known bug: the renderer and reader disagree on where `valueRecommendation:` lives
+  // (field-level vs. under the controlled-term values block), so the flag silently
+  // round-trips to false.
+  @Disabled("YAML round-trip drops valueRecommendation flag")
   @Test public void testRoundTripPreservesValueRecommendationOnControlledTerm()
   {
-    // The renderer emits `valueRecommendation:` only when true; this is a real round-trip probe.
     ControlledTermField original = ControlledTermField.builder()
       .withName("Disease").withValueRecommendationEnabled(true).build();
 

--- a/src/test/java/org/metadatacenter/artifacts/model/core/AnnotationsBuilderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/AnnotationsBuilderTest.java
@@ -11,11 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Group F — Annotations.Builder coverage. The annotations map is order-preserving, so the
- * order assertion is a real invariant (YAML and JSON renderers both emit entries in builder
- * order).
- */
 public class AnnotationsBuilderTest
 {
   @Test public void testLiteralAndIriAnnotationsMixed()

--- a/src/test/java/org/metadatacenter/artifacts/model/core/BuilderValidationTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/BuilderValidationTest.java
@@ -9,14 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Group D — null/invalid-arg validation paths in the field-schema and constraint builders.
- * The bug we caught in PR #37 (YouTubeField positional-argument slot) was exactly this kind
- * of latent issue: a constructor / setter that silently accepted the wrong value. These tests
- * lock in the visible invariants so future refactors don't loosen them.
+ * Null/invalid-arg validation paths in the field-schema and constraint builders. Pins the
+ * visible invariants so future refactors don't silently loosen them.
  */
 public class BuilderValidationTest
 {
-  // ------------------ FieldSchemaArtifactBuilder null guards (via TextField builder) ------
+  // ---- FieldSchemaArtifactBuilder null guards (via TextField builder) ----
 
   @Test public void testBuildRejectsNullName()
   {
@@ -70,7 +68,7 @@ public class BuilderValidationTest
       () -> TextField.builder().withVersion(null));
   }
 
-  // ------------------ TextValueConstraints negative paths -----------------------------
+  // ---- TextValueConstraints negative paths ----
 
   @Test public void testTextValueConstraintsBuilderRejectsEmptyDefaultValue()
   {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/CoreContractPinningTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/CoreContractPinningTest.java
@@ -11,30 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Groups H + L — small contracts worth pinning.
- *
- * <p>**H1.** {@code XsdNumericDatatype.fromString("xsd:int")} has a documented ambiguity:
- * both {@code INTEGER("xsd:int")} and {@code INT("xsd:int")} match. The current
- * enum-declaration-order behavior returns {@code INTEGER}. If someone reorders the constants,
- * callers downstream silently switch to {@code INT} (or fail equality checks). This test
- * pins the current behavior.
- *
- * <p>**L1.** {@code FieldInstanceArtifact.create} must accept an empty {@code jsonLdTypes}
- * list — this is the normal shape for plain literal field instances. Pin it so a future
- * refactor doesn't add a "required" guard.
- *
- * <p>**L2.** {@code Status.fromString} rejects unknown strings (mirrors the version contract
- * locked in by PR #43).
- */
 public class CoreContractPinningTest
 {
   @Test public void testXsdNumericDatatypeIntStringIsDeterministicallyInteger()
   {
-    // INTEGER is declared before INT in the enum (lines 12, 16 of XsdNumericDatatype.java),
-    // so the fromString iteration matches INTEGER first. This test pins that ordering — if
-    // the enum members are ever reordered, this test fails loudly rather than letting the
-    // ambiguity silently flip downstream callers (e.g., JsonValueConstraintsReader L330).
+    // Both XsdNumericDatatype.INTEGER and XsdNumericDatatype.INT carry the text "xsd:int".
+    // fromString iterates in enum-declaration order; INTEGER is declared first, so it wins.
+    // Reordering the constants would silently change which one downstream callers receive.
     XsdNumericDatatype result = XsdNumericDatatype.fromString("xsd:int");
     assertEquals(XsdNumericDatatype.INTEGER, result,
       "Expected INTEGER (first declared); got " + result + ". "
@@ -44,8 +27,7 @@ public class CoreContractPinningTest
 
   @Test public void testFieldInstanceCreateAcceptsEmptyJsonLdTypes()
   {
-    // Normal usage: a literal field instance has no JSON-LD @type. The create factory must
-    // accept an empty list, not throw.
+    // A literal field instance has no JSON-LD @type; the create factory must accept that.
     FieldInstanceArtifact instance = FieldInstanceArtifact.create(
       Collections.emptyList(), Optional.empty(),
       Optional.of("hello"), Optional.empty(), Optional.empty(),

--- a/src/test/java/org/metadatacenter/artifacts/model/core/DatatypeAndVersionTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/DatatypeAndVersionTest.java
@@ -13,11 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Group H — enum / datatype round-trips.
+ * Round-trips for enum / datatype {@code fromString} parsers, plus {@link Version#fromString}.
  *
- * <p>The {@link XsdNumericDatatype#fromString} round-trip notably collides on
- * {@code "xsd:int"} (mapped by both {@code INT} and {@code INTEGER}), so the test
- * asserts the observed first-wins behavior rather than a per-constant identity.
+ * <p>Note: {@link XsdNumericDatatype#fromString} collides on {@code "xsd:int"} (both
+ * {@code INT} and {@code INTEGER} carry that text), so the round-trip is checked on text
+ * equality rather than enum identity. See {@code CoreContractPinningTest} for the explicit
+ * first-wins pinning.
  */
 public class DatatypeAndVersionTest
 {
@@ -68,7 +69,7 @@ public class DatatypeAndVersionTest
 
   @Test public void testVersionFromStringRejectsMalformed()
   {
-    // Sanity for the JsonNodeReaders.readVersion / readModelVersion guard added in PR #43.
+    // JsonNodeReaders.readVersion / readModelVersion rely on this contract — keep them aligned.
     assertThrows(IllegalArgumentException.class, () -> Version.fromString("not-a-version"));
     assertThrows(IllegalArgumentException.class, () -> Version.fromString("1.2"));
     assertThrows(IllegalArgumentException.class, () -> Version.fromString("v1.0.0"));

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ElementInstanceArtifactBuilderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ElementInstanceArtifactBuilderTest.java
@@ -10,10 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Group E (element instance) — exercises the multi-child / attribute-value / removal paths and
- * their duplicate / missing validation guards.
- */
 public class ElementInstanceArtifactBuilderTest
 {
   private static FieldInstanceArtifact literal(String value)

--- a/src/test/java/org/metadatacenter/artifacts/model/core/FieldInstanceArtifactTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/FieldInstanceArtifactTest.java
@@ -255,8 +255,6 @@ public class FieldInstanceArtifactTest
     assertEquals(preferredLabel, fieldInstance.preferredLabel().get());
   }
 
-  // ---------------- Group B: previously-untested instance builders & sealed classifiers ----
-
   @Test
   public void doiFieldInstanceTest()
   {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/FieldSchemaArtifactCopyTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/FieldSchemaArtifactCopyTest.java
@@ -10,12 +10,13 @@ import org.metadatacenter.artifacts.model.core.fields.constraints.TextValueConst
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Group G — cross-cutting copy-builder behavior. The YouTube positional-argument bug
- * (PR #37: outer `language` clobbered `preferredLabel` in the YOUTUBE arm of
- * `FieldSchemaArtifact.create`) was a copy/round-trip regression. These tests guard
- * against the same kind of slot mix-up across every concrete field type, plus the
- * annotations + value-constraints round-trip, and the nested-children paths on
- * template / element schemas.
+ * Cross-cutting copy-builder behavior across all field types, plus annotations and
+ * value-constraints preservation and nested-children copy on template / element schemas.
+ *
+ * <p>The parametrized {@code testCopyPreservesPreferredLabel} guards against positional-
+ * argument slot mix-ups in the {@code FieldSchemaArtifact.create} switch expression — the
+ * kind of bug where an outer variable silently fills the wrong slot for a particular field
+ * arm and the data round-trips to the wrong field.
  */
 public class FieldSchemaArtifactCopyTest
 {
@@ -47,8 +48,8 @@ public class FieldSchemaArtifactCopyTest
 
   @Test public void testCopyPreservesPreferredLabel()
   {
-    // Regression for PR #37: copy via FieldSchemaArtifact.create must preserve preferredLabel
-    // across every field arm of the switch expression.
+    // FieldSchemaArtifact.create must preserve preferredLabel across every field arm of the
+    // switch expression.
     for (FieldSchemaArtifact original : everyFieldVariant()) {
       FieldSchemaArtifact copy = FieldSchemaArtifact.create(
         original.internalName(), original.internalDescription(),

--- a/src/test/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifactBuilderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifactBuilderTest.java
@@ -10,10 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Group E (template instance) — exercises duplicate / remove-then-re-add / attribute-value
- * conflict paths on the template-instance builder.
- */
 public class TemplateInstanceArtifactBuilderTest
 {
   private static FieldInstanceArtifact literal(String value)

--- a/src/test/java/org/metadatacenter/artifacts/model/core/VisitorDepthTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/VisitorDepthTest.java
@@ -12,9 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Group G — Visitor pattern depth. Existing tests cover the single-template happy path; this
- * batch pins the contract for deeply nested templates and multi-instance children, which are
- * the harder paths consumers actually rely on (e.g., REDCap export, terminology lookups).
+ * Visitor coverage for deeply nested templates and multi-instance children — the paths
+ * consumers like REDCap export and terminology lookups exercise.
  */
 public class VisitorDepthTest
 {

--- a/src/test/java/org/metadatacenter/artifacts/model/core/builders/FieldSchemaArtifactBuilderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/builders/FieldSchemaArtifactBuilderTest.java
@@ -1055,8 +1055,6 @@ public class FieldSchemaArtifactBuilderTest {
     Assertions.assertEquals(content, clonedRichTextField.fieldUi().asStaticFieldUi()._content().get());
   }
 
-  // ---------------- Group A: previously-untested linked-style field schemas ----------------
-
   @Test
   public void testCreateDoiField() {
     String name = "DOI";

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/ArtifactParseExceptionTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/ArtifactParseExceptionTest.java
@@ -5,10 +5,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Group B — ArtifactParseException carries fieldKey + path that consumers parse for error
- * display. These tests pin the contract so refactors don't quietly drop the context.
- */
 public class ArtifactParseExceptionTest
 {
   @Test public void testPreservesFieldKey()

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/JsonArtifactReaderNegativePathsTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/JsonArtifactReaderNegativePathsTest.java
@@ -31,10 +31,8 @@ import static org.metadatacenter.model.ModelNodeNames.TEMPLATE_SCHEMA_ARTIFACT_T
 import static org.metadatacenter.model.ModelNodeNames.UI;
 
 /**
- * Group A — JsonArtifactReader negative paths. The existing JsonArtifactReaderTest is all
- * happy-path fixture loads; these tests cover the 25 throw sites in the reader to ensure
- * malformed input fails fast with useful exceptions instead of producing silently-wrong
- * artifacts.
+ * Negative-path tests for JsonArtifactReader: malformed input must fail fast with a useful
+ * exception rather than producing a silently-wrong artifact.
  */
 public class JsonArtifactReaderNegativePathsTest
 {
@@ -59,8 +57,7 @@ public class JsonArtifactReaderNegativePathsTest
 
   @Test public void testReadTemplateThrowsOnWrongJsonLdType()
   {
-    // A template document tagged with the element IRI should be rejected — silently accepting
-    // would let consumers cast Element→Template downstream and explode.
+    // A template document tagged with the element IRI must be rejected, not silently coerced.
     ObjectNode node = baseTemplate("T", "d");
     node.put(JSON_LD_TYPE, ELEMENT_SCHEMA_ARTIFACT_TYPE_IRI);
 
@@ -79,7 +76,6 @@ public class JsonArtifactReaderNegativePathsTest
 
   @Test public void testReadFieldThrowsOnMalformedVersion()
   {
-    // Parallels JsonNodeReaders.readVersion contract (PR #43) — through the public API.
     ObjectNode node = baseField("Test", "d");
     node.put(PAV_VERSION, "not-a-version");
     node.with(UI).put("inputType", "textfield");
@@ -91,8 +87,7 @@ public class JsonArtifactReaderNegativePathsTest
 
   @Test public void testReadTemplateInstanceThrowsOnMissingIsBasedOn()
   {
-    // A template-instance with no isBasedOn is unparseable — we'd have nothing to validate
-    // the instance against.
+    // Without `isBasedOn` there's no template to validate the instance against.
     ObjectNode node = mapper.createObjectNode();
     node.put(JSON_LD_TYPE, mapper.createArrayNode());
     node.put(SCHEMA_ORG_NAME, "Inst");
@@ -148,12 +143,11 @@ public class JsonArtifactReaderNegativePathsTest
     assertThrows(Exception.class, () -> JsonNodeReaders.readOffsetDateTime(node, "/", "ts"));
   }
 
-  // ---- Group I: JSON shape robustness ----
+  // ---- JSON shape robustness ----
 
   @Test public void testReadTemplateThrowsOnArrayProperties()
   {
-    // The JSON Schema `properties` value must be an object. An array (or any non-object)
-    // is malformed.
+    // JSON Schema `properties` must be an object; an array (or other non-object) is malformed.
     ObjectNode node = baseTemplate("T", "d");
     node.set(JSON_SCHEMA_PROPERTIES, mapper.createArrayNode());
 
@@ -174,7 +168,6 @@ public class JsonArtifactReaderNegativePathsTest
 
   @Test public void testReadFieldThrowsOnMissingUi()
   {
-    // The `_ui` block is required on every field schema; its absence is malformed.
     ObjectNode node = baseField("Test", "d");
     node.remove(UI);
 
@@ -183,8 +176,7 @@ public class JsonArtifactReaderNegativePathsTest
 
   @Test public void testReadTemplateThrowsOnWrongJsonSchemaType()
   {
-    // The top-level `type` JSON-Schema key must be `object`; rejecting `array` keeps the
-    // reader from accepting documents that look superficially right.
+    // Top-level JSON Schema `type` must be `object`.
     ObjectNode node = baseTemplate("T", "d");
     node.put(JSON_SCHEMA_TYPE, "array");
 

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/JsonValueConstraintsReaderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/JsonValueConstraintsReaderTest.java
@@ -19,16 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Group C — JsonValueConstraintsReader has 401 LOC and zero direct tests. Value constraints
- * control field validation, so silent bugs here mean fields validate the wrong things.
- */
 public class JsonValueConstraintsReaderTest
 {
   private final ObjectMapper mapper = new ObjectMapper();
-
-  // VALUE_CONSTRAINTS_* keys are all literal strings under JSON Schema; using literals here
-  // keeps the test focused on shape rather than constants.
 
   @Test public void testReadOntologyValueConstraint()
   {
@@ -61,7 +54,7 @@ public class JsonValueConstraintsReaderTest
     assertEquals(1, results.size());
     assertEquals("ONT1", results.get(0).acronym());
 
-    // Non-array value: returns empty (silently — documenting the contract).
+    // Non-array value silently returns empty rather than throwing.
     ObjectNode notArray = mapper.createObjectNode();
     notArray.put("ontologies", "not an array");
     assertTrue(
@@ -116,7 +109,6 @@ public class JsonValueConstraintsReaderTest
 
   @Test public void testReadValueConstraintsActionFullShape()
   {
-    // The action shape carries all fields; absence of the array node returns empty.
     ObjectNode action = mapper.createObjectNode();
     action.put("termUri", "https://purl.org/datacite/v4.4/TranslatedTitle");
     action.put("sourceUri", "https://purl.org/datacite/v4.4/TitleType");
@@ -132,7 +124,7 @@ public class JsonValueConstraintsReaderTest
     assertEquals(ValueConstraintsActionType.DELETE, result.action());
     assertEquals(5, result.to().get());
 
-    // And the array-reading helper bubbles up an exception on non-object entries.
+    // Array-reading helper throws on non-object entries.
     ObjectNode parent = mapper.createObjectNode();
     ArrayNode arr = parent.putArray("actions");
     arr.add("not-an-object");

--- a/src/test/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReaderNegativePathsTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/reader/YamlArtifactReaderNegativePathsTest.java
@@ -11,9 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Group D — YAML reader negative paths. The reader has well-defined throws at boundaries
- * (children must be a list, child entries must be maps, types must be known) that no test
- * exercised. Hand-authored YAML is common so these messages have to surface useful errors.
+ * Negative-path tests for YamlArtifactReader: hand-authored YAML is common, so malformed
+ * documents must surface useful error messages rather than producing wrong artifacts.
  */
 public class YamlArtifactReaderNegativePathsTest
 {
@@ -87,8 +86,7 @@ public class YamlArtifactReaderNegativePathsTest
 
   @Test public void testReadVersionRejectsInvalidString()
   {
-    // Mirrors the JSON readVersion contract (PR #43) on the YAML side. A field with an
-    // invalid `version:` must surface a parse error, not silently coerce.
+    // An invalid `version:` must surface a parse error, not silently coerce.
     LinkedHashMap<String, Object> field = new LinkedHashMap<>();
     field.put("type", "text-field");
     field.put("name", "X");


### PR DESCRIPTION
## Summary
Removed comments in the test files that referenced the workflow that produced the tests — phrasings like \"Group A — …\", \"PR #N\", \"this PR\", \"previously-untested\", \"Captured as part of this PR\". These had no value to a future reader and would only confuse anyone seeing them out of session context.

Behavior is unchanged. Comments that documented real contracts (e.g., \"hand-authored YAML is common, so malformed documents must surface useful errors\", or the XSD INT/INTEGER first-wins note) were rewritten to drop the process framing but keep the substantive content.

17 test files touched, 55 insertions / 132 deletions.

## Test plan
- [x] `mvn test` — 404 passing, 0 failures, 2 skipped (unchanged)
- [x] `mvn spotless:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)