### PR TITLE
Make withOntologyValueConstraint take Integer to match withValueSetValueConstraint

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/core/ControlledTermField.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/ControlledTermField.java
@@ -108,9 +108,10 @@ public sealed interface ControlledTermField extends FieldSchemaArtifact
     }
 
     public ControlledTermFieldBuilder withOntologyValueConstraint(URI uri, String acronym, String name,
-      Optional<Integer> numTerms)
+      Integer numTerms)
     {
-      valueConstraintsBuilder.withOntologyValueConstraint(new OntologyValueConstraint(uri, acronym, name, numTerms));
+      valueConstraintsBuilder.withOntologyValueConstraint(
+        new OntologyValueConstraint(uri, acronym, name, Optional.of(numTerms)));
       return this;
     }
 


### PR DESCRIPTION
## Summary
Two sister methods in \`ControlledTermFieldBuilder\`, ~14 lines apart, disagreed on how to pass an optional \"number of terms\":

\`\`\`java
withOntologyValueConstraint(URI, String, String, Optional<Integer> numTerms)   // outlier
withValueSetValueConstraint(URI, String, String, Integer        numberOfTerms) // prevailing
\`\`\`

The Integer-and-wrap-internally pattern is what every other \`with*\` builder in the library uses (raw param + a no-param overload for the absent case). \`withOntologyValueConstraint\` was the only outlier in the entire main source tree. This brings it into line.

## Test plan
- [x] \`mvn test\` — 421 passing, 0 failures
- [x] \`mvn spotless:check\` — clean

## Compatibility note
Binary-incompatible for the specific 4-arg overload (callers passing \`Optional<Integer>\` will need to either call \`.get()\` if they know it's present, or use the existing 3-arg overload for the absent case). No in-repo callers were affected.