### PR TITLE
Add withoutAttributeValueFieldGroup to instance builders

### DIFF
--- a/src/main/java/org/metadatacenter/artifacts/model/core/ElementInstanceArtifact.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/ElementInstanceArtifact.java
@@ -340,7 +340,23 @@ public non-sealed interface ElementInstanceArtifact extends InstanceArtifact, Pa
       return this;
     }
 
-    // TODO Add withoutAttributeValueFieldGroup
+    public Builder withoutAttributeValueFieldGroup(String attributeValueFieldGroupName)
+    {
+      if (!childKeys.contains(attributeValueFieldGroupName)
+        || !attributeValueFieldInstanceGroups.containsKey(attributeValueFieldGroupName))
+        throw new IllegalArgumentException(
+          "attribute-value field group " + attributeValueFieldGroupName + " not present in instance");
+
+      // Remove both the group name itself and each inner field-instance name from childKeys.
+      Map<String, FieldInstanceArtifact> groupEntries =
+        attributeValueFieldInstanceGroups.get(attributeValueFieldGroupName);
+      childKeys.removeAll(groupEntries.keySet());
+      childKeys.remove(attributeValueFieldGroupName);
+
+      attributeValueFieldInstanceGroups.remove(attributeValueFieldGroupName);
+
+      return this;
+    }
 
     public ElementInstanceArtifact build()
     {

--- a/src/main/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifact.java
+++ b/src/main/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifact.java
@@ -345,7 +345,23 @@ public non-sealed interface TemplateInstanceArtifact extends InstanceArtifact, P
       return this;
     }
 
-    // TODO Add withoutAttributeValueFieldGroup
+    public Builder withoutAttributeValueFieldGroup(String attributeValueFieldGroupName) {
+      if (!childKeys.contains(attributeValueFieldGroupName)
+          || !attributeValueFieldInstanceGroups.containsKey(attributeValueFieldGroupName)) {
+        throw new IllegalArgumentException(
+            "attribute-value field group " + attributeValueFieldGroupName + " not present in instance");
+      }
+
+      // Remove both the group name itself and each inner field-instance name from childKeys.
+      Map<String, FieldInstanceArtifact> groupEntries =
+          attributeValueFieldInstanceGroups.get(attributeValueFieldGroupName);
+      childKeys.removeAll(groupEntries.keySet());
+      childKeys.remove(attributeValueFieldGroupName);
+
+      attributeValueFieldInstanceGroups.remove(attributeValueFieldGroupName);
+
+      return this;
+    }
 
     public TemplateInstanceArtifact build() {
       return new TemplateInstanceArtifactRecord(jsonLdContext, jsonLdTypes, jsonLdId, name, description, createdBy,

--- a/src/test/java/org/metadatacenter/artifacts/model/core/ElementInstanceArtifactBuilderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/ElementInstanceArtifactBuilderTest.java
@@ -64,6 +64,31 @@ public class ElementInstanceArtifactBuilderTest
     assertTrue(ex.getMessage().contains("not present"));
   }
 
+  @Test public void testWithoutAttributeValueFieldGroupRemovesGroupAndInnerKeys()
+  {
+    LinkedHashMap<String, FieldInstanceArtifact> group = new LinkedHashMap<>();
+    group.put("attr1", literal("a"));
+    group.put("attr2", literal("b"));
+
+    ElementInstanceArtifact element = ElementInstanceArtifact.builder()
+      .withAttributeValueFieldGroup("custom-attrs", group)
+      .withoutAttributeValueFieldGroup("custom-attrs")
+      .build();
+
+    assertTrue(element.attributeValueFieldInstanceGroups().isEmpty());
+    // Both the group name and the inner attribute names must come back out of childKeys,
+    // otherwise re-adding either would fail the duplicate-child check.
+    assertTrue(element.childKeys().isEmpty());
+  }
+
+  @Test public void testWithoutAttributeValueFieldGroupRejectsAbsentName()
+  {
+    ElementInstanceArtifact.Builder builder = ElementInstanceArtifact.builder();
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+      () -> builder.withoutAttributeValueFieldGroup("never-added"));
+    assertTrue(ex.getMessage().contains("not present"));
+  }
+
   @Test public void testWithAttributeValueFieldGroupRejectsOverlappingKey()
   {
     // Group field-instance names must not collide with already-registered child keys.

--- a/src/test/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifactBuilderTest.java
+++ b/src/test/java/org/metadatacenter/artifacts/model/core/TemplateInstanceArtifactBuilderTest.java
@@ -61,4 +61,29 @@ public class TemplateInstanceArtifactBuilderTest
     assertThrows(IllegalArgumentException.class,
       () -> builder.withAttributeValueFieldGroup("attrs", group));
   }
+
+  @Test public void testWithoutAttributeValueFieldGroupAllowsReadditionUnderSameName()
+  {
+    LinkedHashMap<String, FieldInstanceArtifact> first = new LinkedHashMap<>();
+    first.put("attr1", literal("a"));
+    LinkedHashMap<String, FieldInstanceArtifact> second = new LinkedHashMap<>();
+    second.put("attr1", literal("b"));
+
+    // Remove must clear childKeys cleanly enough that re-adding under the same name works.
+    TemplateInstanceArtifact instance = minimalBuilder()
+      .withAttributeValueFieldGroup("custom", first)
+      .withoutAttributeValueFieldGroup("custom")
+      .withAttributeValueFieldGroup("custom", second)
+      .build();
+
+    assertEquals("b", instance.attributeValueFieldInstanceGroups().get("custom").get("attr1").jsonLdValue().get());
+  }
+
+  @Test public void testWithoutAttributeValueFieldGroupRejectsAbsentName()
+  {
+    TemplateInstanceArtifact.Builder builder = minimalBuilder();
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+      () -> builder.withoutAttributeValueFieldGroup("never-added"));
+    assertTrue(ex.getMessage().contains("not present"));
+  }
 }


### PR DESCRIPTION
## Summary
Both \`TemplateInstanceArtifact.Builder\` and \`ElementInstanceArtifact.Builder\` had \`without*\` removal methods symmetric to \`with*\` additions for every kind of child (single/multi-instance field/element), except for attribute-value field groups — flagged as \`// TODO Add withoutAttributeValueFieldGroup\` in both files.

This closes that gap. Removal cleans up:
- The group name from \`childKeys\`
- Each inner field-instance name from \`childKeys\` (these are added by \`withAttributeValueFieldGroup\`, so the mirror must remove them too)
- The entry from \`attributeValueFieldInstanceGroups\`

Throws \`IllegalArgumentException\` if the named group isn't present, matching the contract on the other \`without*\` methods.

## Tests added
- \`ElementInstanceArtifactBuilderTest.testWithoutAttributeValueFieldGroupRemovesGroupAndInnerKeys\` — verifies both the group name and inner attribute names are cleared from \`childKeys\` (otherwise re-adding either would fail the duplicate-child check).
- \`ElementInstanceArtifactBuilderTest.testWithoutAttributeValueFieldGroupRejectsAbsentName\`
- \`TemplateInstanceArtifactBuilderTest.testWithoutAttributeValueFieldGroupAllowsReadditionUnderSameName\` — round-trip remove/re-add under the same group name.
- \`TemplateInstanceArtifactBuilderTest.testWithoutAttributeValueFieldGroupRejectsAbsentName\`

## Test plan
- [x] \`mvn test\` — 425 passing (4 new), 0 failures
- [x] \`mvn spotless:check\` — clean